### PR TITLE
Use haggadah text from firestore

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,28 +7,37 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: robcherry/docker-chromedriver:latest
+      #image: robcherry/docker-chromedriver:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3 #Setup Node
         with:
           node-version: '18'
-      - uses: DeLaGuardo/setup-clojure@11.0
-      - name: run test
-        env: 
-          GCLOUD_PROJECT: "my-haggadah"
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MY_HAGGADAH}}
-        run: |
 
-          which chromedriver
-          chromedriver --help
-          ls /usr/bin/google-chrome
-          which google-chrome
-          google-chrome --version
-          chromedriver --version
+      - name: Prepare java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+
+      - uses: DeLaGuardo/setup-clojure@11.0
+        with:
+          cli: 1.10.1.693              # Clojure CLI based on tools.deps
+          lein: 2.9.1                  # Leiningen
+      # - name: run test
+      #   env: 
+      #     GCLOUD_PROJECT: "my-haggadah"
+      #     GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_MY_HAGGADAH}}
+      #   run: |
+
+      #     which chromedriver
+      #     chromedriver --help
+      #     ls /usr/bin/google-chrome
+      #     which google-chrome
+      #     google-chrome --version
+      #     chromedriver --version
           #npm install
           # npm install -g firebase-tools
           # npm test

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if
-          request.time < timestamp.date(2023, 5, 28);
+      allow read, write: if true;
+          
     }
   }
 }

--- a/local_emulators/firebase.json
+++ b/local_emulators/firebase.json
@@ -1,0 +1,24 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9097
+    },
+    "functions": {
+      "port": 5009
+    },
+    "firestore": {
+      "port": 8084
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  },
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "functions": {
+    "source": "../functions"
+  }
+}

--- a/local_emulators/firestore.indexes.json
+++ b/local_emulators/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/local_emulators/firestore.rules
+++ b/local_emulators/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if
+          request.time < timestamp.date(2023, 5, 28);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
 				"highlight.js": "11.5.1",
 				"markdown-clj": "^1.10.3",
 				"react": "17.0.2",
-				"react-dom": "17.0.2",
-				"socket.io-parser": "^4.2.3"
+				"react-dom": "17.0.2"
 			},
 			"devDependencies": {
 				"autoprefixer": "^10.4.14",
@@ -23,7 +22,9 @@
 				"postcss": "^8.4.23",
 				"postcss-import": "^15.1.0",
 				"shadow-cljs": "2.20.5",
-				"tailwindcss": "^3.3.2"
+				"socket.io-parser": "^4.2.3",
+				"tailwindcss": "^3.3.2",
+				"ws": "^8.13.0"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -917,7 +918,8 @@
 		"node_modules/@socket.io/component-emitter": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+			"dev": true
 		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
@@ -5012,6 +5014,27 @@
 			"integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==",
 			"dev": true
 		},
+		"node_modules/shadow-cljs/node_modules/ws": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/side-channel": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -5077,6 +5100,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
 			"integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
+			"dev": true,
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1"
@@ -5089,6 +5113,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -5104,7 +5129,8 @@
 		"node_modules/socket.io-parser/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/socket.io/node_modules/debug": {
 			"version": "4.3.4",
@@ -5783,16 +5809,16 @@
 			"devOptional": true
 		},
 		"node_modules/ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
 			"dev": true,
 			"engines": {
-				"node": ">=8.3.0"
+				"node": ">=10.0.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
+				"utf-8-validate": ">=5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -6624,7 +6650,8 @@
 		"@socket.io/component-emitter": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+			"integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+			"dev": true
 		},
 		"@tootallnate/once": {
 			"version": "2.0.0",
@@ -9833,6 +9860,15 @@
 				"source-map-support": "^0.4.15",
 				"which": "^1.3.1",
 				"ws": "^7.4.6"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "7.5.9",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+					"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+					"dev": true,
+					"requires": {}
+				}
 			}
 		},
 		"shadow-cljs-jar": {
@@ -9905,6 +9941,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
 			"integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
+			"dev": true,
 			"requires": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1"
@@ -9914,6 +9951,7 @@
 					"version": "4.3.4",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -9921,7 +9959,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -10427,9 +10466,9 @@
 			"devOptional": true
 		},
 		"ws": {
-			"version": "7.5.9",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-			"integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+			"integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
 	"devDependencies": {
 		"autoprefixer": "^10.4.14",
 		"karma": "^6.4.2",
-      "socket.io-parser": "^4.2.3",
 		"karma-chrome-launcher": "^3.2.0",
 		"karma-cljs-test": "^0.1.0",
 		"postcss": "^8.4.23",
 		"postcss-import": "^15.1.0",
 		"shadow-cljs": "2.20.5",
-		"tailwindcss": "^3.3.2"
+		"socket.io-parser": "^4.2.3",
+		"tailwindcss": "^3.3.2",
+		"ws": "^8.13.0"
 	}
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -42,7 +42,7 @@
                    haggadah.fb.auth/FIREBASE_AUTH_HOST  "http://localhost:9099"
                    haggadah.fb.auth/FIREBASE_HOSTING_HOST  "localhost:5000"
                    haggadah.fb.auth/FIREBASE_FUNCTIONS_HOST  "localhost:5001"
-                   haggadah.fb.auth/FIREBASE_FIRESTORE_HOST  "localhost:8080"}}}
+                   haggadah.fb.firestore/FIREBASE_FIRESTORE_HOST  "localhost:8080"}}}
                 :release
                 {:build-options
                  {:ns-aliases

--- a/src/haggadah/core.cljs
+++ b/src/haggadah/core.cljs
@@ -9,6 +9,7 @@
    ["firebase/app" :as fba]
    ["firebase/firestore" :as fs]
    [haggadah.fb.config :as cfg]
+   [haggadah.fb.firestore :as fb-fs]
    [haggadah.fb.auth :as fb-auth]
    ))
 
@@ -30,7 +31,7 @@
     (let [cfg (clj->js config)]
       (reset! firebase-instance (fba/initializeApp cfg))
       (fb-auth/init @firebase-instance)
-      (fs/getFirestore @firebase-instance))))
+      (fb-fs/init @firebase-instance))))
 
 (defn firebase-init!
   []

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -47,12 +47,20 @@
        (.then on-success)
        (.catch on-error))))
 
+(re-frame/reg-event-db
+ ::set-haggadah
+ (fn [db [_ snap]]
+   (assoc db :haggadah-text
+          (-> snap
+              (. data)
+              (js->clj :keywordize-keys true)))))
+
 (re-frame/reg-event-fx
  ::set-user
  (fn-traced [{:keys [db]} [_ user]]
             {:db (assoc db :name (.-email user))
              ::fetch-haggadah {:uid (.-uid user)
-                               :on-success println
+                               :on-success #(re-frame/dispatch [::set-haggadah %])
                                :on-error #(js/console.log % :error)}}))
 
 

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -4,12 +4,14 @@
    [shadow.resource :as rc]
    [goog.object :as gobj]
    [cljsjs.marked]
+   [haggadah.fb.firestore :as fb-fs]
    ["marked" :as mark]
    ["react" :as react]
    [haggadah.db :as db]
    [day8.re-frame.tracing :refer-macros [fn-traced]]
    [haggadah.fb.auth :as auth]
-   [re-frame.core :as rf]))
+   [re-frame.core :as rf])
+ #_ (:import com.google.firebase.cloud.FirestoreClient))
 
 (def interceptors [re-frame/trim-v])
 
@@ -33,10 +35,24 @@
  (fn [_ [_]]
    {::email-login! {:email "han@skywalker.com" :password "123456789" :on-success #(re-frame/dispatch [::set-user %] ) :on-error #(js/console.log % :error)}}))
 
-(re-frame/reg-event-db
+
+#_(re-frame/reg-event-db
+ ::render-login-text
+ (fn [db [_ uid]]
+   (let [haggadah
+         (-> (fs/Doc )
+          (FirestoreClient/getFirestore)
+             (.collection "users")
+             (.document "user1")
+             (.get "haggadah-text"))]
+   (assoc db :haggadah-text
+          (js/marked.parse haggadah)))))
+
+(re-frame/reg-event-fx
  ::set-user
- (fn-traced [db [_ user]]
-            (assoc db :name (.-email user))))
+ (fn-traced [{:keys [db]} [_ user]]
+            {:db (assoc db :name (.-email user))}
+            #_(rf/dispatch [::render-login-text (.-id user)])))
 
 
 
@@ -47,12 +63,16 @@
   )
 
 
-(re-frame/reg-event-db
+
+
+#_(re-frame/reg-event-db
  ::render-login-text
- (fn [db [_ file]]
+ (fn [db [_ _]]
+   {::email-login!
+    {:email "han@skywalker.com" :password "123456789" :on-success #(re-frame/dispatch [::render-haggadah %] ) :on-error #(js/console.log % :error)}
+
+    }
    (assoc db :haggadah-text (js/marked.parse example-haggadah))))
-
-
 
 
 

--- a/src/haggadah/fb/firestore.cljs
+++ b/src/haggadah/fb/firestore.cljs
@@ -1,0 +1,8 @@
+(ns haggadah.fb.firestore
+  (:require
+   ["firebase/firestore" :as fs]))
+
+(defonce firestore (atom nil))
+
+(defn init [firebase-instance]
+  (reset! firestore (fs/getFirestore firebase-instance)))

--- a/src/haggadah/fb/firestore.cljs
+++ b/src/haggadah/fb/firestore.cljs
@@ -4,5 +4,16 @@
 
 (defonce firestore (atom nil))
 
+(goog-define FIREBASE_FIRESTORE_HOST false)
+
+(defn instance
+  []
+  @firestore)
+
 (defn init [firebase-instance]
-  (reset! firestore (fs/getFirestore firebase-instance)))
+  (println  FIREBASE_FIRESTORE_HOST)
+  (reset! firestore (fs/getFirestore firebase-instance))
+  (when FIREBASE_FIRESTORE_HOST
+    (let [[host port] (clojure.string/split FIREBASE_FIRESTORE_HOST #":")]
+      (fs/connectFirestoreEmulator @firestore host (js/parseInt port)))))
+

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -20,9 +20,9 @@
       {:class (styles/level1)}
       (str "Hello from " @name ". This is the Home Page." "We're glad to see you.")]
 
-     (let [haggadah-text (re-frame/subscribe [::subs/haggadah-text])]
-       [:div  {:dangerouslySetInnerHTML #js{:__html @haggadah-text} :id "haggadah-text"}])
-
+     (let [{:keys [haggadah-text]} @(re-frame/subscribe [::subs/haggadah-text])]
+       (when haggadah-text
+         [:div  {:dangerouslySetInnerHTML #js{:__html (js/marked.parse haggadah-text)} :id "haggadah-text"}]))
      [:div 
       [:button {:on-click #(re-frame/dispatch [::events/login :admin]) :data-test-id "login"} "Log In as Admin"]]
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -19,9 +19,13 @@
      [:h1 
       {:class (styles/level1)}
       (str "Hello from " @name ". This is the Home Page." "We're glad to see you.")]
+
+     (let [haggadah-text (re-frame/subscribe [::subs/haggadah-text])]
+       [:div  {:dangerouslySetInnerHTML #js{:__html @haggadah-text} :id "haggadah-text"}])
+
      [:div 
-      [:button {:on-click #(re-frame/dispatch [::events/login :admin]) :data-test-id "login"} "Log In as Admin"]
-      [:button {:on-click #(re-frame/dispatch  [::events/navigate :haggadah]  )}"Render text"]]
+      [:button {:on-click #(re-frame/dispatch [::events/login :admin]) :data-test-id "login"} "Log In as Admin"]]
+
      [:div.underline
       [:a {:on-click #(re-frame/dispatch [::events/navigate :about])}
        "go to About Page"]]

--- a/test/acceptance/admin_login_test.clj
+++ b/test/acceptance/admin_login_test.clj
@@ -74,23 +74,21 @@
   "The default haggadah")
 
 (def actual-haggadah-text
-  "Hello Why, who are you\nThis is the example haggadah\nLook at all we can show you")
+  "This is Amir's excellent Haggadah")
 
 (t/deftest show-text-test
-  (t/testing "Default text"
-    (let [_ (e/go driver "http://localhost:5000/")
-          _ (e/click-visible driver {:tag :button :fn/text "Render text"})
-          _ (e/screenshot driver "screenshots/haggadah-text.png")
-          actual (e/get-element-text driver {:tag :div :id "haggadah-text"})]
-      (t/is (= default-haggadah-text actual))))
   (t/testing "When the current user has a haggadah"
     (let [db (FirestoreClient/getFirestore)
           haggadah {"haggadah-text" "## This is Amir's excellent Haggadah"}
-          result (-> db
+          write (-> db
                      (.collection "users")
                      (.document "user1")
-                     (.set haggadah)
-                     (.get ))]
-      (println result))))
+                     (.set haggadah))
+          _ (e/go driver "http://localhost:5000/")
+          _ (e/click-visible driver {:tag :button :data-test-id "login"})
+          _ (e/wait-has-text-everywhere driver actual-haggadah-text)
+          haggadah-text (e/get-element-text driver {:tag :div :id "haggadah-text"})]
+
+      (t/is (= actual-haggadah-text haggadah-text)))))
 
 ;; "http://localhost:8080/emulator/v1/projects/firestore-emulator-example/databases/(default)/documents"

--- a/test/acceptance/admin_login_test.clj
+++ b/test/acceptance/admin_login_test.clj
@@ -4,6 +4,7 @@
              [environ.core :refer [env]])
   (:import com.google.firebase.FirebaseApp
            com.google.firebase.internal.EmulatorCredentials
+           com.google.firebase.cloud.FirestoreClient
             com.google.cloud.firestore.Firestore
             com.google.firebase.FirebaseOptions$Builder
             com.google.firebase.auth.FirebaseAuth
@@ -41,10 +42,11 @@
    :disabled (. user-record isDisabled)})
 
 (defn create-user
-  [{:keys [email pwd]}]
+  [{:keys [email pwd id]}]
   (let [firebase-auth (. FirebaseAuth getInstance)
         create-request (doto (new UserRecord$CreateRequest)
                          (.setEmail email)
+                         (.setUid id)
                          (.setPassword pwd))]
     (convert-user-record-to-map (. firebase-auth createUser create-request))))
 
@@ -53,13 +55,13 @@
   Post: initializes all features of firebase, such as firestore, authentication,"
   [tests]
   (init)
+  (create-user {:email "han@skywalker.com"  :pwd "123456789" :id "user1"})
   (tests))
 
 (t/use-fixtures :once init-firebase)
 
 (t/deftest message-test
   (t/testing "When the admin user exists"
-    (create-user {:email "han@skywalker.com"  :pwd "123456789"})
     (doto driver
       (e/go "http://localhost:5000/")
        (e/click-visible {:tag :button :data-test-id "login"})
@@ -81,9 +83,12 @@
           _ (e/screenshot driver "screenshots/haggadah-text.png")
           actual (e/get-element-text driver {:tag :div :id "haggadah-text"})]
       (t/is (= default-haggadah-text actual))))
-  (t/testing "Actual text"
-    (let [_ (e/click-visible driver {:tag :button :fn/text "Click here to see the haggadah"})
-          real-text (e/get-element-text driver {:tag :div :id "haggadah-text"})]
-      (t/is (= actual-haggadah-text real-text))))
-  #_(t/testing "Uploading document to firestore"
-    (fs/addDoc (fs/collection ))))
+  (t/testing "When the current user has a haggadah"
+    (let [db (FirestoreClient/getFirestore)
+          haggadah {"haggadah-text" "## This is Amir's excellent Haggadah"}
+          result (-> db
+                     (.collection "users")
+                     (.document "user1")
+                     (.set haggadah)
+                     (.get ))]
+      (println result))))

--- a/test/acceptance/admin_login_test.clj
+++ b/test/acceptance/admin_login_test.clj
@@ -92,3 +92,5 @@
                      (.set haggadah)
                      (.get ))]
       (println result))))
+
+;; "http://localhost:8080/emulator/v1/projects/firestore-emulator-example/databases/(default)/documents"


### PR DESCRIPTION
## Summary
Changed the event which renders the haggadah text to now read from firestore and use the text there.

closes #5
## Changes

### events.cljs
* Added fetch haggadah event which grabs the haggadah in firestore
* Changed set-haggadah event so it grabs the data from the haggadah snapshot
* Changed set-user so it launches the set-haggadah event

### admin_login_test.clj
* Added another scenario to show-text-test which grabs the haggadah from firestore and checks if it was rendered  


 
