### PR TITLE
render bracha

### DIFF
--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -192,7 +192,7 @@
   [:div.container.hero.is-medium
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:div.hero-body
-       [:div.container {:dangerouslySetInnerHTML #js{:__html (js/marked.parse text #js{:mangle false :headerIds false})} :id "haggadah-text"}]])])
+       [:div.container.content {:dangerouslySetInnerHTML #js{:__html (js/marked.parse text #js{:mangle false :headerIds false})} :id "haggadah-text"}]])])
 
 (defn about-panel
   []

--- a/test/acceptance/admin_login_test.clj
+++ b/test/acceptance/admin_login_test.clj
@@ -134,43 +134,53 @@
    (e/screenshot  "screenshots/create-haggadah-test-admin-exists-before-clicking-create.png")))
 
 (defn create-haggadah
-  [d]
+  [d title text]
   (doto d
    (e/click-visible {:tag :a :data-test-id "create-haggadah"})
    (e/wait-visible {:tag :input :id "haggadah-title"})
    (e/screenshot  "screenshots/create-haggadah-test-admin-exists-after-clicking-create.png")
    (e/fill  {:tag :input :id "haggadah-title"} k/home (k/with-shift k/end) k/delete)
-   (e/fill {:tag :input :id "haggadah-title"} new-haggadah-title)
+   (e/fill {:tag :input :id "haggadah-title"} title)
    (e/fill {:tag :input :id "haggadah-text"} k/home (k/with-shift k/end) k/delete)
-   (e/fill {:tag :input :id "haggadah-text"} new-haggadah-text)
+   (e/fill {:tag :input :id "haggadah-text"} text)
    (e/screenshot "screenshots/create-haggadah-test-admin-exists-before-creating-haggadah.png")
    (e/click-visible {:tag :a :data-test-id "add-haggadah"})
    (e/click-visible {:tag :a :data-test-id "return-dashboard"})))
 
 (defn click-on-haggadah
-  [d]
+  [d title text]
   (doto d
    (e/screenshot "screenshots/create-haggadah-test-admin-exists-before-clicking-haggadah.png")
-   (e/click-visible {:tag :a :fn/text new-haggadah-title})
-   (e/wait-has-text-everywhere parsed-haggadah-text)
+   (e/click-visible {:tag :a :fn/text title})
+   (e/wait-has-text-everywhere text)
    (e/screenshot "screenshots/create-haggadah-test-admin-exists-haggadah-text.png")))
 
 (t/deftest create-haggadah-test
   (t/testing "When the current user creates a new haggadah"
     (let [_ (home->dashboard driver)
-          _ (create-haggadah driver)
-          _ (click-on-haggadah driver)
+          _ (create-haggadah driver new-haggadah-title new-haggadah-text)
+          _ (click-on-haggadah driver new-haggadah-title parsed-haggadah-text)
           haggadah-text (e/get-element-text driver {:tag :div :id "haggadah-text"})]
       (t/is (= parsed-haggadah-text haggadah-text)))))
 
 (t/deftest refresh-page-test
   (t/testing "When the current user refreshes the haggadah"
     (let [_ (home->dashboard driver)
-          _ (click-on-haggadah driver)
+          _ (click-on-haggadah driver new-haggadah-title parsed-haggadah-text)
           _ (e/refresh driver)
           _ (e/wait-has-text-everywhere driver parsed-haggadah-text)
           haggadah-text (e/get-element-text driver {:tag :div :id "haggadah-text"})]
       (t/is (= parsed-haggadah-text haggadah-text)))))
 
+
+#_(t/deftest bracha-rendered-test
+  (t/testing "When the current user creates a haggadah with a bracha"
+    (let [_ (home->dashboard driver)
+          _ (create-haggadah driver content)
+          _ (click-on-haggadah driver title)
+          _ (e/wait-has-text-everywhere driver parsed-bracha)
+           bracha (e/get-element-text driver {:tag :h3 :id "haggadah-text"})]
+      (t/is (= parsed-bracha bracha)))
+    ))
 ;; "http://localhost:8080/emulator/v1/projects/firestore-emulator-example/databases/(default)/documents"
 

--- a/test/acceptance/admin_login_test.clj
+++ b/test/acceptance/admin_login_test.clj
@@ -172,15 +172,18 @@
           haggadah-text (e/get-element-text driver {:tag :div :id "haggadah-text"})]
       (t/is (= parsed-haggadah-text haggadah-text)))))
 
+(def unparsed-bracha "### סַבְרִי מָרָנָן וְרַבָּנָן וְרַבּוֹתַי. בָּרוּךְ אַתָּה ה', אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם בּוֹרֵא פְּרִי הַגָּפֶן")
+(def haggadah-with-bracha-title "Haggadah with a bracha")
+(def parsed-bracha "סַבְרִי מָרָנָן וְרַבָּנָן וְרַבּוֹתַי. בָּרוּךְ אַתָּה ה', אֱלֹהֵינוּ מֶלֶךְ הָעוֹלָם בּוֹרֵא פְּרִי הַגָּפֶן")
 
-#_(t/deftest bracha-rendered-test
+(t/deftest bracha-rendered-test
   (t/testing "When the current user creates a haggadah with a bracha"
     (let [_ (home->dashboard driver)
-          _ (create-haggadah driver content)
-          _ (click-on-haggadah driver title)
+          _ (create-haggadah driver haggadah-with-bracha-title unparsed-bracha)
+          _ (click-on-haggadah driver haggadah-with-bracha-title parsed-bracha)
           _ (e/wait-has-text-everywhere driver parsed-bracha)
-           bracha (e/get-element-text driver {:tag :h3 :id "haggadah-text"})]
-      (t/is (= parsed-bracha bracha)))
-    ))
+          _ (e/screenshot driver "screenshots/bracha-rendered-test-bracha-is-visible")
+           bracha (e/get-element-text driver {:tag :h3 :fn/text parsed-bracha})]
+      (t/is (= parsed-bracha bracha)))))
 ;; "http://localhost:8080/emulator/v1/projects/firestore-emulator-example/databases/(default)/documents"
 


### PR DESCRIPTION
## Summary
When the user inserts hebrew bracha in the haggadah it is rendered correctly

closes #30

## Changes

### src/haggadah/views.cljs
* Changed haggadah-view-panel so that haggadah content is rendered using markdown styles

### test/acceptance/admin_login_test.clj
* Added a new test that checks that a bracha is rendered correctly

