### PR TITLE
create haggadah with song using dsl

### DIFF
--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -34,7 +34,6 @@
            [:div.has-text-right.is-size-5 {:data-testid :bracha-content} content]]
     :else [:div]))
 
-
 (defn parse-haggadah
   "Pre: takes a Haggadah
   Post: returns the same Haggadah represented in hiccup"

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -20,18 +20,30 @@
   Post: returns a Haggadah with song and title passed within"
   [title song]
   {:content 
-   {:bracha {:title title :content song}}})
+   {:song {:title title :content song}}})
   
+
+(defn render-bracha
+  "Pre: takes a title and content for a bracha
+  Post: returns a hiccup representation of the bracha"
+  [title content]
+  [:div
+   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
+   [:div.has-text-right.is-size-5 {:data-testid :bracha-content} content]])
+
+(defn render-song
+  "Pre: takes a title and content for a song
+  Post: returns a hiccup representation of the song"
+  [title content]
+  [:div
+   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 title]
+   [:div.has-text-right.is-size-5 content]])
 
 (defn haggadah->hiccup
   [[k {:keys [title content]}]]
   (case k
-    :bracha [:div
-             [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
-             [:div.has-text-right.is-size-5 {:data-testid :bracha-content }content]]
-    :song [:div
-           [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
-           [:div.has-text-right.is-size-5 {:data-testid :bracha-content} content]]
+    :bracha (render-bracha title content)
+    :song (render-song title content)
     :else [:div]))
 
 (defn parse-haggadah

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -15,12 +15,23 @@
 (defonce haggadah
   (create-haggadah "Wine" bracha))
 
+(defn create-haggadah-with-song
+  "Pre: takes a song and its title
+  Post: returns a Haggadah with song and title passed within"
+  [title song]
+  {:content 
+   {:bracha {:title title :content song}}})
+  
+
 (defn haggadah->hiccup
   [[k {:keys [title content]}]]
   (case k
     :bracha [:div
              [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
              [:div.has-text-right.is-size-5 {:data-testid :bracha-content }content]]
+    :song [:div
+           [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
+           [:div.has-text-right.is-size-5 {:data-testid :bracha-content} content]]
     :else [:div]))
 
 

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -1,0 +1,22 @@
+(ns haggadah.dsl-test
+  (:require [haggadah.dsl :as dsl]
+            [cljs.test :as t :include-macros true]))
+
+(def title "Ki lo nae")
+
+(def song
+  " כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה.
+  אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו יֹאמְרוּ לוֹ: לְךָ וּלְךָ, לְךָ כִּי לְךָ, לְךָ אַף לְךָ, לְךָ ה' הַמַּמְלָכָה, כִּי לוֹ נָאֵה, כִּי לוֹ יָאֶה. ")
+
+
+(def haggadah-as-hiccup
+  [:div
+   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
+   [:div.has-text-right.is-size-5 {:data-testid :bracha-content } song]])
+
+(t/deftest haggadah-with-song-test
+  (t/testing "When the user creates a Haggadah with a song in it and parses it using the dsl, the correct hiccup representation of the Haggadah will be returned"
+    (let [haggadah (dsl/create-haggadah-with-song title song)
+          hiccup-rep (dsl/parse-haggadah (:content haggadah))
+          actual-haggadah haggadah-as-hiccup]
+      (t/is (= actual-haggadah hiccup-rep)))))

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -11,8 +11,8 @@
 
 (def haggadah-as-hiccup
   [:div
-   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
-   [:div.has-text-right.is-size-5 {:data-testid :bracha-content } song]])
+   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2  title]
+   [:div.has-text-right.is-size-5 song]])
 
 (t/deftest haggadah-with-song-test
   (t/testing "When the user creates a Haggadah with a song in it and parses it using the dsl, the correct hiccup representation of the Haggadah will be returned"


### PR DESCRIPTION
## Summary
The dsl can now create and parse a Haggadah with a song in it.

closes #56

## Changes

### test/haggadah/dsl_test.cljs
* Added `haggadah-with-song-test` to check that when a Haggadah with a song is parsed using the dsl, it is converted into its correct hiccup representation

