### PR TITLE
create haggadah with table using dsl

### DIFF
--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -22,6 +22,12 @@
   {:content 
    {:song {:title title :content song}}})
   
+(defn create-haggadah-with-table
+  "Pre: takes a table
+  Post: returns a Haggadah with a table within"
+  [title table]
+  {:content
+   {:table {:title title :content table }}})
 
 (defn render-bracha
   "Pre: takes a title and content for a bracha
@@ -39,11 +45,40 @@
    [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 title]
    [:div.has-text-right.is-size-5 content]])
 
+{:1 ["cont" "more" "cont"]}
+
+[["1" "2" "3" "4"]
+ ["1" "2" "3" "4"]]
+(mapcat str [1 2 3])
+
+
+(defn ->cell
+  "Pre: takes a cell from a table
+  Post: returns the hiccup representation of the cell"
+  [cell]
+  [:td cell])
+
+(defn ->row
+  "Pre: takes a row from a table
+  Post: returns the hiccup representation of the row"
+  [row]
+  (into [:tr] (map ->cell row)))
+
+(defn render-table
+  "Pre: takes a title and the content for a table
+  Post: returns the hiccup representation of the table"
+  [title table]
+  [:div
+   [:div.has-text-centered.pb-4.is-size-5 title]
+   [:table.is-bordered.is-flex.is-justify-content-center.table
+    (into [:tbody] (map ->row table))]])
+
 (defn haggadah->hiccup
   [[k {:keys [title content]}]]
   (case k
     :bracha (render-bracha title content)
     :song (render-song title content)
+    :table (render-table title content)
     :else [:div]))
 
 (defn parse-haggadah

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -23,7 +23,7 @@
    {:song {:title title :content song}}})
   
 (defn create-haggadah-with-table
-  "Pre: takes a table
+  "Pre: takes the title of a table and its content
   Post: returns a Haggadah with a table within"
   [title table]
   {:content

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -45,13 +45,6 @@
    [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 title]
    [:div.has-text-right.is-size-5 content]])
 
-{:1 ["cont" "more" "cont"]}
-
-[["1" "2" "3" "4"]
- ["1" "2" "3" "4"]]
-(mapcat str [1 2 3])
-
-
 (defn ->cell
   "Pre: takes a cell from a table
   Post: returns the hiccup representation of the cell"

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -201,28 +201,6 @@
 
 
 
-(def table
-  [:div
-   [:div.has-text-centered.pb-4.has-text-weight-bold.is-size-5 "Las Diez Plagas"]
-   [:table.is-bordered.is-flex.is-justify-content-center.table
-    [:thead]
-    [:tbody
-     [:tr
-      [:td "Sangre"]
-      [:td "דָּם"]]
-     [:tr  
-      [:td "Ranas"]
-      [:td "צְפַרְדֵּעַ"]]
-     [:tr  
-      [:td "Piojos"]
-      [:td "כִּנִּים"]]
-     [:tr  
-      [:td "Bestias"]
-      [:td "עָרוֹב"]]
-     [:tr  
-      [:td "Peste"]
-      [:td "דֶּבֶר"]]]]])
-
 (defn haggadah-view-panel
   []
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -212,14 +212,23 @@
       [:td "דָּם"]]
      [:tr  
       [:td "Ranas"]
-      [:td "צְפַרְדֵּעַ"]]]]])
+      [:td "צְפַרְדֵּעַ"]]
+     [:tr  
+      [:td "Piojos"]
+      [:td "כִּנִּים"]]
+     [:tr  
+      [:td "Bestias"]
+      [:td "עָרוֹב"]]
+     [:tr  
+      [:td "Peste"]
+      [:td "דֶּבֶר"]]]]])
 
 (defn haggadah-view-panel
   []
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:section.container.is-flex
-       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text}table #_text ]])])
+       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} text ]])])
 
 (defn about-panel
   []

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -199,6 +199,21 @@
                                                                                          %])
                               :id "submit"} "Create"]]]]]]]))
 
+
+
+(def table
+  [:div
+   [:div.has-text-centered.pb-4.has-text-weight-bold.is-size-5 "Las Diez Plagas"]
+   [:table.is-bordered.is-flex.is-justify-content-center.table
+    [:thead]
+    [:tbody
+     [:tr
+      [:td "Sangre"]
+      [:th "דָּם"]]
+     [:tr  
+      [:td "Ranas"]
+      [:th "צְפַרְדֵּעַ"]]]]])
+
 (defn haggadah-view-panel
   []
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -209,17 +209,17 @@
     [:tbody
      [:tr
       [:td "Sangre"]
-      [:th "דָּם"]]
+      [:td "דָּם"]]
      [:tr  
       [:td "Ranas"]
-      [:th "צְפַרְדֵּעַ"]]]]])
+      [:td "צְפַרְדֵּעַ"]]]]])
 
 (defn haggadah-view-panel
   []
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:section.container.is-flex
-       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} text ]])])
+       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text}table #_text ]])])
 
 (defn about-panel
   []

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -68,7 +68,7 @@
 (def table-title "Las Diez Plagas")
 
 (t/deftest haggadah-with-table-test
-  (t/testing "When the user creates a Haggadah with a table in it and the Haggadah is parsed, the correct hiccup representation of the Haggadah will be returned"
+  (t/testing "When the user creates a Haggadah with a table in it and the Haggadah is parsed, the correct hiccup representation of the Haggadah is returned"
     (let [haggadah (dsl/create-haggadah-with-table table-title table-content)
           hiccup-rep (dsl/parse-haggadah (:content haggadah))]
       (t/is (= haggadah-with-table hiccup-rep)))))

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -27,14 +27,14 @@
   [:div
    [:div.has-text-centered.pb-4.is-size-5 "TITLE"]
    [:table.is-bordered.is-flex.is-justify-content-center.table
-    [:thead]
+    [:tdead]
     [:tbody
      [:tr
       [:td "Sangre"]
-      [:th "דָּם"]]
+      [:td "דָּם"]]
      [:tr  
       [:td "Ranas"]
-      [:th "צְפַרְדֵּעַ"]]]]])
+      [:td "צְפַרְדֵּעַ"]]]]])
 
 
 (def haggadah-with-table
@@ -44,19 +44,19 @@
     [:tbody
      [:tr
       [:td "Sangre"]
-      [:th "דָּם"]]
+      [:td "דָּם"]]
      [:tr  
       [:td "Ranas"]
-      [:th "צְפַרְדֵּעַ"]]
+      [:td "צְפַרְדֵּעַ"]]
      [:tr  
       [:td "Piojos"]
-      [:th "כִּנִּים"]]
+      [:td "כִּנִּים"]]
      [:tr  
       [:td "Bestias"]
-      [:th "עָרוֹב"]]
+      [:td "עָרוֹב"]]
      [:tr  
       [:td "Peste"]
-      [:th "דֶּבֶר"]]]]])
+      [:td "דֶּבֶר"]]]]])
 
 (def table-content
   [["Sangre" "דָּם"]

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -20,3 +20,55 @@
           hiccup-rep (dsl/parse-haggadah (:content haggadah))
           actual-haggadah haggadah-as-hiccup]
       (t/is (= actual-haggadah hiccup-rep)))))
+
+
+
+(def table
+  [:div
+   [:div.has-text-centered.pb-4.is-size-5 "TITLE"]
+   [:table.is-bordered.is-flex.is-justify-content-center.table
+    [:thead]
+    [:tbody
+     [:tr
+      [:td "Sangre"]
+      [:th "דָּם"]]
+     [:tr  
+      [:td "Ranas"]
+      [:th "צְפַרְדֵּעַ"]]]]])
+
+
+(def haggadah-with-table
+  [:div
+   [:div.has-text-centered.pb-4.is-size-5 "Las Diez Plagas"]
+   [:table.is-bordered.is-flex.is-justify-content-center.table
+    [:tbody
+     [:tr
+      [:td "Sangre"]
+      [:th "דָּם"]]
+     [:tr  
+      [:td "Ranas"]
+      [:th "צְפַרְדֵּעַ"]]
+     [:tr  
+      [:td "Piojos"]
+      [:th "כִּנִּים"]]
+     [:tr  
+      [:td "Bestias"]
+      [:th "עָרוֹב"]]
+     [:tr  
+      [:td "Peste"]
+      [:th "דֶּבֶר"]]]]])
+
+(def table-content
+  [["Sangre" "דָּם"]
+   ["Ranas" "צְפַרְדֵּעַ"]
+   ["Piojos"  "כִּנִּים"]
+   ["Bestias"  "עָרוֹב"]
+   ["Peste" "דֶּבֶר"]])
+
+(def table-title "Las Diez Plagas")
+
+(t/deftest haggadah-with-table-test
+  (t/testing "When the user creates a Haggadah with a table in it and the Haggadah is parsed, the correct hiccup representation of the Haggadah will be returned"
+    (let [haggadah (dsl/create-haggadah-with-table table-title table-content)
+          hiccup-rep (dsl/parse-haggadah (:content haggadah))]
+      (t/is (= haggadah-with-table hiccup-rep)))))


### PR DESCRIPTION
## Summary

The user can view a Haggadah which contains a table

closes #58

## Changes

### test/haggadah/dsl_test.cljs
* Added `haggadah-with-table-test` to check that a Haggadah with a table is converted correctly into its hiccup representation
