### PR TITLE
create haggadah with subsection using dsl

### DIFF
--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -30,12 +30,18 @@
   {:content
    {:table {:title title :content table }}})
 
+(defn make-subsection
+  "Pre: takes a collection of items to include in the subsection
+  Post: returns a subsection with the collection of items within"
+  [coll]
+  (apply conj {} coll))
+
 (defn create-haggadah-with-subsection
   "Pre: takes a subsection title and content
   Post: returns a Haggadah with a subsection within"
   [title content]
   {:content
-   {:sucsection {:title title :content content}}})
+   {:subsection {:title title :content (make-subsection content)}}})
 
 (defn render-bracha
   "Pre: takes a title and content for a bracha
@@ -50,7 +56,7 @@
   Post: returns a hiccup representation of the song"
   [title content]
   [:div
-   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 title]
+   [:div.has-text-centered.has-text-weight-bold.is-size-4.pb-2 title]
    [:div.has-text-right.is-size-5 content]])
 
 (defn ->cell
@@ -83,39 +89,15 @@
    ["Bestias"  "עָרוֹב"]
    ["Peste" "דֶּבֶר"]])
 
-(def bracha-con (:content haggadah))
-(def song
-  (:content
-   (create-haggadah-with-song "kljlkjl" "hiello ehte")))
+(declare haggadah->hiccup)
 
-(def coll
-  [bracha-con song])
-
-
-(concat {:hi 2} {:whi 3})
-(conj {} bracha-con song)
-(conj {} {:hi 2} {:whi 3})
-
-(defn make-subsec-content
-  "Pre: takes a collection of items to have for the subsection
-Post: returns a subsection with the collection of items within"
-  [coll]
-(apply conj {} coll))
-
-(make-subsec-content coll)
-
-(defn render-subsection
-  "Pre: takes a title and content for a subsection
+(defn render-subsec
+  "Pre: takes a aubsection title and content
   Post: returns the hiccup representation of the subsection"
   [title content]
-  [:div title
-   (map haggadah->hiccup content)])
-
-(into {:song {}} (:content haggadah))
-
-(render-subsection "hlkjhj"
-(:content haggadah)
-                   )
+  (into [:div
+         [:div.has-text-weight-bold.is-size-3 title]]
+        (map haggadah->hiccup content)))
 
 (defn haggadah->hiccup
   [[k {:keys [title content]}]]
@@ -123,8 +105,9 @@ Post: returns a subsection with the collection of items within"
     :bracha (render-bracha title content)
     :song (render-song title content)
     :table (render-table title content)
-    :subsection (render-subsection title content)
+    :subsection (render-subsec title content)
     :else [:div]))
+
 
 (defn parse-haggadah
   "Pre: takes a Haggadah

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -15,6 +15,7 @@
 (defonce haggadah
   (create-haggadah "Wine" bracha))
 
+
 (defn create-haggadah-with-song
   "Pre: takes a song and its title
   Post: returns a Haggadah with song and title passed within"
@@ -28,6 +29,13 @@
   [title table]
   {:content
    {:table {:title title :content table }}})
+
+(defn create-haggadah-with-subsection
+  "Pre: takes a subsection title and content
+  Post: returns a Haggadah with a subsection within"
+  [title content]
+  {:content
+   {:sucsection {:title title :content content}}})
 
 (defn render-bracha
   "Pre: takes a title and content for a bracha
@@ -66,12 +74,56 @@
    [:table.is-bordered.is-flex.is-justify-content-center.table
     (into [:tbody] (map ->row table))]])
 
+{:bracha {} :song {}}
+
+(def table-content
+  [["Sangre" "דָּם"]
+   ["Ranas" "צְפַרְדֵּעַ"]
+   ["Piojos"  "כִּנִּים"]
+   ["Bestias"  "עָרוֹב"]
+   ["Peste" "דֶּבֶר"]])
+
+(def bracha-con (:content haggadah))
+(def song
+  (:content
+   (create-haggadah-with-song "kljlkjl" "hiello ehte")))
+
+(def coll
+  [bracha-con song])
+
+
+(concat {:hi 2} {:whi 3})
+(conj {} bracha-con song)
+(conj {} {:hi 2} {:whi 3})
+
+(defn make-subsec-content
+  "Pre: takes a collection of items to have for the subsection
+Post: returns a subsection with the collection of items within"
+  [coll]
+(apply conj {} coll))
+
+(make-subsec-content coll)
+
+(defn render-subsection
+  "Pre: takes a title and content for a subsection
+  Post: returns the hiccup representation of the subsection"
+  [title content]
+  [:div title
+   (map haggadah->hiccup content)])
+
+(into {:song {}} (:content haggadah))
+
+(render-subsection "hlkjhj"
+(:content haggadah)
+                   )
+
 (defn haggadah->hiccup
   [[k {:keys [title content]}]]
   (case k
     :bracha (render-bracha title content)
     :song (render-song title content)
     :table (render-table title content)
+    :subsection (render-subsection title content)
     :else [:div]))
 
 (defn parse-haggadah

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -47,7 +47,7 @@
   "Pre: takes a title and content for a bracha
   Post: returns a hiccup representation of the bracha"
   [title content]
-  [:div
+  [:div.pt-3
    [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 {:data-testid :bracha-title} title]
    [:div.has-text-right.is-size-5 {:data-testid :bracha-content} content]])
 
@@ -55,7 +55,7 @@
   "Pre: takes a title and content for a song
   Post: returns a hiccup representation of the song"
   [title content]
-  [:div
+  [:div.pt-3
    [:div.has-text-centered.has-text-weight-bold.is-size-4.pb-2 title]
    [:div.has-text-right.is-size-5 content]])
 
@@ -75,12 +75,11 @@
   "Pre: takes a title and the content for a table
   Post: returns the hiccup representation of the table"
   [title table]
-  [:div
+  [:div.pt-3
    [:div.has-text-centered.pb-4.is-size-5 title]
    [:table.is-bordered.is-flex.is-justify-content-center.table
     (into [:tbody] (map ->row table))]])
 
-{:bracha {} :song {}}
 
 (def table-content
   [["Sangre" "דָּם"]
@@ -92,11 +91,11 @@
 (declare haggadah->hiccup)
 
 (defn render-subsec
-  "Pre: takes a aubsection title and content
+  "Pre: takes a subsection title and content
   Post: returns the hiccup representation of the subsection"
   [title content]
-  (into [:div
-         [:div.has-text-weight-bold.is-size-3 title]]
+  (into [:div 
+         [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 title]]
         (map haggadah->hiccup content)))
 
 (defn haggadah->hiccup

--- a/src/haggadah/styles.cljs
+++ b/src/haggadah/styles.cljs
@@ -109,6 +109,3 @@
    :width :100%
    :padding "20px 0px"})
 
-(defclass haggadah-item
-  []
-  {:padding-top :1.5rem})

--- a/src/haggadah/styles.cljs
+++ b/src/haggadah/styles.cljs
@@ -109,4 +109,6 @@
    :width :100%
    :padding "20px 0px"})
 
-
+(defclass haggadah-item
+  []
+  {:padding-top :1.5rem})

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -3,6 +3,7 @@
    [re-frame.core :as re-frame]
    [haggadah.styles :as styles]
    [haggadah.subs :as subs]
+   [haggadah.dsl-test :as ds-test]
    [reitit.frontend.easy :as rfe]
    [haggadah.events :as events]
    [goog.string.format]))
@@ -201,12 +202,17 @@
 
 
 
+(def haggadah-with-subsection
+  [:div ds-test/subsection-title
+   ds-test/haggadah-as-hiccup
+   ds-test/haggadah-with-table])
+
 (defn haggadah-view-panel
   []
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:section.container.is-flex
-       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} text ]])])
+       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} haggadah-with-subsection #_text ]])])
 
 (defn about-panel
   []

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -203,9 +203,10 @@
 
 
 (def haggadah-with-subsection
-  [:div ds-test/subsection-title
-   ds-test/haggadah-as-hiccup
-   ds-test/haggadah-with-table])
+  [:div
+   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 ds-test/subsection-title]
+    ds-test/haggadah-as-hiccup
+    ds-test/haggadah-with-table])
 
 (defn haggadah-view-panel
   []

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -213,7 +213,7 @@
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:section.container.is-flex
-       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} haggadah-with-subsection #_text ]])])
+       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} text ]])])
 
 (defn about-panel
   []

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -3,7 +3,6 @@
    [re-frame.core :as re-frame]
    [haggadah.styles :as styles]
    [haggadah.subs :as subs]
-   [haggadah.dsl-test :as ds-test]
    [reitit.frontend.easy :as rfe]
    [haggadah.events :as events]
    [goog.string.format]))
@@ -202,11 +201,6 @@
 
 
 
-(def haggadah-with-subsection
-  [:div
-   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 ds-test/subsection-title]
-    ds-test/haggadah-as-hiccup
-    ds-test/haggadah-with-table])
 
 (defn haggadah-view-panel
   []

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -24,7 +24,6 @@
           actual-haggadah haggadah-as-hiccup]
       (t/is (= actual-haggadah hiccup-rep)))))
 
-
 (def haggadah-with-table
   [:div.pt-3
    [:div.has-text-centered.pb-4.is-size-5 "Las Diez Plagas"]
@@ -39,7 +38,7 @@
      [:tr  
       [:td "Piojos"]
       [:td "כִּנִּים"]]
-     [:tr  
+     [:tr
       [:td "Bestias"]
       [:td "עָרוֹב"]]
      [:tr  

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -11,7 +11,7 @@
 
 (def haggadah-as-hiccup
   [:div.pt-3
-   [:div.has-text-centered.has-text-weight-bold.is-size-4.pb-2  title]
+   [:div.has-text-centered.has-text-weight-bold.is-size-4.pb-2 title]
    [:div.has-text-right.is-size-5 song]])
 
 (dsl/create-haggadah-with-song title song)

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -14,6 +14,9 @@
    [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2  title]
    [:div.has-text-right.is-size-5 song]])
 
+(dsl/create-haggadah-with-song title song)
+
+
 (t/deftest haggadah-with-song-test
   (t/testing "When the user creates a Haggadah with a song in it and parses it using the dsl, the correct hiccup representation of the Haggadah will be returned"
     (let [haggadah (dsl/create-haggadah-with-song title song)
@@ -73,15 +76,19 @@
           hiccup-rep (dsl/parse-haggadah (:content haggadah))]
       (t/is (= haggadah-with-table hiccup-rep)))))
 
-(def subsec-title "Subsection")
+(def subsection-title "Subsection")
 
 (def haggadah-with-subsection
-  [:div subsec-title
+  [:div subsection-title
    haggadah-as-hiccup
    haggadah-with-table])
 
+(def subsection-content
+  [{:song {:title title :content song}}
+   {:table {:title table-title :content table-content}}])
 
-#_(t/deftest haggadah-with-subsection-test
+
+(t/deftest haggadah-with-subsection-test
   (t/testing "When the user creates a Haggadah with a subsection and the Haggadah is parsed, the correct hiccup representation of the Haggadah is returned"
     (let [haggadah (dsl/create-haggadah-with-subsection subsection-title subsection-content)
           hiccup-rep (dsl/parse-haggadah (:content haggadah))]

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -10,8 +10,8 @@
 
 
 (def haggadah-as-hiccup
-  [:div
-   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2  title]
+  [:div.pt-3
+   [:div.has-text-centered.has-text-weight-bold.is-size-4.pb-2  title]
    [:div.has-text-right.is-size-5 song]])
 
 (dsl/create-haggadah-with-song title song)
@@ -25,23 +25,8 @@
       (t/is (= actual-haggadah hiccup-rep)))))
 
 
-
-(def table
-  [:div
-   [:div.has-text-centered.pb-4.is-size-5 "TITLE"]
-   [:table.is-bordered.is-flex.is-justify-content-center.table
-    [:tdead]
-    [:tbody
-     [:tr
-      [:td "Sangre"]
-      [:td "דָּם"]]
-     [:tr  
-      [:td "Ranas"]
-      [:td "צְפַרְדֵּעַ"]]]]])
-
-
 (def haggadah-with-table
-  [:div
+  [:div.pt-3
    [:div.has-text-centered.pb-4.is-size-5 "Las Diez Plagas"]
    [:table.is-bordered.is-flex.is-justify-content-center.table
     [:tbody
@@ -79,7 +64,8 @@
 (def subsection-title "Subsection")
 
 (def haggadah-with-subsection
-  [:div subsection-title
+  [:div
+   [:div.has-text-centered.has-text-weight-bold.is-size-3.pb-2 subsection-title]
    haggadah-as-hiccup
    haggadah-with-table])
 
@@ -92,5 +78,4 @@
   (t/testing "When the user creates a Haggadah with a subsection and the Haggadah is parsed, the correct hiccup representation of the Haggadah is returned"
     (let [haggadah (dsl/create-haggadah-with-subsection subsection-title subsection-content)
           hiccup-rep (dsl/parse-haggadah (:content haggadah))]
-      (t/is (= haggadah-with-subsection hiccup-rep)))
-    ))
+      (t/is (= haggadah-with-subsection hiccup-rep)))))

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -72,3 +72,18 @@
     (let [haggadah (dsl/create-haggadah-with-table table-title table-content)
           hiccup-rep (dsl/parse-haggadah (:content haggadah))]
       (t/is (= haggadah-with-table hiccup-rep)))))
+
+(def subsec-title "Subsection")
+
+(def haggadah-with-subsection
+  [:div subsec-title
+   haggadah-as-hiccup
+   haggadah-with-table])
+
+
+#_(t/deftest haggadah-with-subsection-test
+  (t/testing "When the user creates a Haggadah with a subsection and the Haggadah is parsed, the correct hiccup representation of the Haggadah is returned"
+    (let [haggadah (dsl/create-haggadah-with-subsection subsection-title subsection-content)
+          hiccup-rep (dsl/parse-haggadah (:content haggadah))]
+      (t/is (= haggadah-with-subsection hiccup-rep)))
+    ))


### PR DESCRIPTION
## Summary

The user can now view a Haggadah which contains a subsection

Here is a short example subsection:
<img width="1030" alt="image" src="https://github.com/ebarylko/my-haggadah/assets/62489101/1f7b8a7f-8bfa-4c42-b9af-4526159a3ae0">


closes #60

## Changes

### test/haggadah/dsl_test.cljs
* Added `haggadah-with-subsection-test` which checks that a Haggadah with a subsection is converted correctly into its hiccup representation

