### PR TITLE
create seder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ List the file changed, and note the changes applied to the file. Do this for all
 
 ## Changing workflows
 
-If a workflow is changed, run `act pulll_request` to see if the change to the workflow works correctly. 
+If a workflow is changed, run `act pull_request` to see if the change to the workflow works correctly. 
 
 The container will be run without access to the local cache, leading to longer completion times. 
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The container will be run without access to the local cache, leading to longer c
 
 For quicker completion times, commit changes and push to remote, which will run the github actions with the local cache.
 
+### google-chrome-stable version used in workflow
+-
+-The version used for google chrome is hardcoded. When there is an update to the latest version of chromedriver, you will need to change the version of google chrome so it matches the major version of chromedriver.
+
 ## Runnning firebase emulators
 
 Run `firebase emulators:start`

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -182,16 +182,6 @@
                 :on-success #(re-frame/dispatch [::push-state :haggadah-success])
                 :on-error (keyword->func ::error)}}))
 
-(re-frame/reg-fx
- ::add-haggadah!
- (fn [{:keys [path haggadah on-success on-error]}]
-   (-> (firestore/instance)
-       (fire/collection (clojure.string/join "/" path))
-       (fire/addDoc (clj->js haggadah))
-       (.then on-success)
-       (.catch on-error))))
-
-
 (re-frame/reg-event-fx
  ::login
  interceptors

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -98,6 +98,11 @@
                :on-error (keyword->func on-error)}}
     {})))
 
+(re-frame/reg-event-db
+ ::create-seder-modal
+ (fn [db [_ id]]
+   (assoc db :seder-modal id)))
+
 (re-frame/reg-event-fx
  ::signout
  (fn [_ [_]]

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -103,25 +103,27 @@
 
 
 (def route-events
-  {:dashboard [::fetch-haggadot {:on-success ::set-haggadot}]
-   :haggadah-view [::fetch-haggadah {:on-success ::set-haggadah }]
-   :haggadah-edit [::fetch-haggadah {:on-success ::set-haggadah }]})
+  {:dashboard [[::fetch-haggadot {:on-success ::set-haggadot}]]
+   :haggadah-view [[::fetch-haggadah {:on-success ::set-haggadah }]]
+   :haggadah-edit [[::fetch-haggadah {:on-success ::set-haggadah }]]})
 
-(re-frame/reg-event-db
- ::do-nothing
- (fn [db [_]]
-   db))
+
+(defn setup-events
+  "Pre: takes a collection of events
+  Post: returns a collection of events waiting to be dispatched"
+  [events]
+  (mapv (fn [event] [:dispatch event]) events))
 
 (re-frame/reg-event-fx
  ::store-user-info
  (fn [{:keys [db]}[_ user]]
    (if user 
      (let [route (get-in db [:current-route :data :name])
-           fx (get route-events route [])
-           user-db (:db db)]
+           fx (->> (get route-events route [])
+                setup-events)]
        {:db (-> db
                 (assoc :name (.-email user)  :uid (.-uid user) :user :registered))
-        :fx [[:dispatch fx]]})
+        :fx fx})
      {:db (assoc db :name nil :uid nil :user :unregistered)})))
 
 

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -103,6 +103,28 @@
  (fn [db [_ id]]
    (assoc db :seder-modal id)))
 
+(re-frame/reg-event-db
+ ::hide-seder-modal
+ (fn [db [_]]
+   (dissoc db :seder-modal)))
+
+(re-frame/reg-event-fx
+ ::seder-success
+ (fn [{:keys [db]} [_ seder]]
+   {:db db
+    :fx [[:dispatch [::fetch-sedarim {:on-success [::set-collection :sedarim]}]]
+         [:dispatch [::hide-seder-modal]]]}))
+
+
+(re-frame/reg-event-fx
+ ::create-seder
+ (fn [{:keys [db]} [_ haggadah-id title]]
+   {::add-doc! {:document-path ["users" (:uid db) "seders"]
+                :content {:haggadah-path (clojure.string/join "/" ["users" (:uid db) "haggadot" haggadah-id])
+                          :title title
+                          :createdAt (js/Date.)}
+                :on-success #(re-frame/dispatch [::seder-success %])}}))
+
 (re-frame/reg-event-fx
  ::signout
  (fn [_ [_]]

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -103,7 +103,7 @@
 
 
 (def route-events
-  {:dashboard [[::fetch-haggadot {:on-success ::set-haggadot}]]
+  {:dashboard [[::fetch-haggadot {:on-success [::set-collection :haggadot ]}]]
    :haggadah-view [[::fetch-haggadah {:on-success ::set-haggadah }]]
    :haggadah-edit [[::fetch-haggadah {:on-success ::set-haggadah }]]})
 
@@ -203,6 +203,17 @@
   Post: triggers an event which stores the user info "
   [user]
   (re-frame/dispatch [::store-user-info user]))
+
+(re-frame/reg-event-db
+ ::set-collection
+ (fn [db [_ field snap]]
+   (let [docs (->> snap (.-docs) js->clj)
+         ids (map #(.-id %) docs)]
+     (assoc db field
+            (->> docs
+                 (map #(.data %))
+                 (map #(js->clj % :keywordize-keys true))
+                 (map #(assoc %2 :id %1) ids))))))
 
 (re-frame/reg-event-db
  ::set-haggadot

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -89,6 +89,14 @@
 
 
 (re-frame/reg-event-fx
+ ::fetch-sedarim
+ (fn [{:keys [db]} [_ {:keys [on-success on-error] :or {on-error :error}}]]
+   {::query! {:path ["users" (:uid db) "seders"]
+              :order-by #(fire/query % (fire/orderBy "createdAt" "desc"))
+              :on-success (keyword->func on-success)
+              :on-error (keyword->func on-error)}}))
+
+(re-frame/reg-event-fx
  ::signout
  (fn [_ [_]]
    {::signout! {:on-success #(re-frame/dispatch [::push-state :home %])
@@ -103,7 +111,8 @@
 
 
 (def route-events
-  {:dashboard [[::fetch-haggadot {:on-success [::set-collection :haggadot ]}]]
+  {:dashboard [[::fetch-haggadot {:on-success [::set-collection :haggadot ]}]
+               [::fetch-sedarim {:on-success [::set-collection :sedarim]}]]
    :haggadah-view [[::fetch-haggadah {:on-success ::set-haggadah }]]
    :haggadah-edit [[::fetch-haggadah {:on-success ::set-haggadah }]]})
 

--- a/src/haggadah/routes.cljs
+++ b/src/haggadah/routes.cljs
@@ -16,7 +16,6 @@
    {:db db
     :fx (events/setup-events events)}))
 
-
 (def routes
   [
    ["/" {:name      :home

--- a/src/haggadah/routes.cljs
+++ b/src/haggadah/routes.cljs
@@ -9,7 +9,12 @@
    [haggadah.views :as views]
    [haggadah.events :as events]))
 
-
+(defn run-events
+  "Pre: takes a collection of events
+  Post: dispatches every event in the collection"
+  [events]
+  (doseq [event events]
+    (re-frame/dispatch event)))
 
 
 (def routes
@@ -28,12 +33,12 @@
     ["" {:name :dashboard
          :view views/dashboard-panel
          :link-text  "Submit"
-        :controllers [{:start (fn [_] (re-frame/dispatch (:dashboard events/route-events)))}]}]
+        :controllers [{:start (fn [_] (run-events (:dashboard events/route-events)))}]}]
     ["/:id" {:name :haggadah-view
              :view views/haggadah-view-panel
              :link-text "haggadah"
              :controllers [{:start (fn []
-                                     (re-frame/dispatch (:haggadah-view events/route-events)))}]}]]
+                                     (run-events (:haggadah-view events/route-events)))}]}]]
    ["/haggadah-creation"
     ["" {:name :haggadah-creation
          :view views/haggadah-creation-panel}]

--- a/src/haggadah/routes.cljs
+++ b/src/haggadah/routes.cljs
@@ -9,12 +9,12 @@
    [haggadah.views :as views]
    [haggadah.events :as events]))
 
-(defn run-events
-  "Pre: takes a collection of events
-  Post: dispatches every event in the collection"
-  [events]
-  (doseq [event events]
-    (re-frame/dispatch event)))
+
+(re-frame/reg-event-fx
+ ::run-events
+ (fn [{:keys [db]} [_ events]]
+   {:db db
+    :fx (events/setup-events events)}))
 
 
 (def routes
@@ -33,12 +33,11 @@
     ["" {:name :dashboard
          :view views/dashboard-panel
          :link-text  "Submit"
-        :controllers [{:start (fn [_] (run-events (:dashboard events/route-events)))}]}]
+        :controllers [{:start (fn [_] (re-frame/dispatch [::run-events (:dashboard events/route-events)]))}]}]
     ["/:id" {:name :haggadah-view
              :view views/haggadah-view-panel
              :link-text "haggadah"
-             :controllers [{:start (fn []
-                                     (run-events (:haggadah-view events/route-events)))}]}]]
+             :controllers [{:start (fn [] (re-frame/dispatch [::run-events (:haggadah-view events/route-events)]))}]}]]
    ["/haggadah-creation"
     ["" {:name :haggadah-creation
          :view views/haggadah-creation-panel}]

--- a/src/haggadah/subs.cljs
+++ b/src/haggadah/subs.cljs
@@ -51,3 +51,8 @@
  ::dropdown
  (fn [db _]
    (:dropdown db)))
+
+(re-frame/reg-sub
+ ::sedarim
+ (fn [db _]
+   (:sedarim db)))

--- a/src/haggadah/subs.cljs
+++ b/src/haggadah/subs.cljs
@@ -56,3 +56,8 @@
  ::sedarim
  (fn [db _]
    (:sedarim db)))
+
+(re-frame/reg-sub
+ ::seder-modal
+ (fn [db _]
+   (:seder-modal db)))

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -138,7 +138,8 @@
       [:div
        [:h1.is-size-3
         "Haggadot created"]
-       (let [haggadot @(re-frame/subscribe [::subs/haggadot])]
+       (let [haggadot @(re-frame/subscribe [::subs/haggadot])
+             sedarim @(re-frame/subscribe [::subs/sedarim])]
          (when haggadot
            [:ul.haggadot 
             (for [{:keys [title id]} haggadot :when id] 
@@ -146,8 +147,17 @@
                          [:a.haggadah-link {:data-testid :haggadah-link 
                                             :href (href :haggadah-view {:id id})} title]
                          [:a.button.is-small {:data-testid :create-seder
-                                              :on-click #(re-frame/dispatch [::events/create-seder-modal id])} "Create Seder"]])]))] ]]]
-   [wave-bottom]])
+                                              :on-click #(re-frame/dispatch [::events/create-seder-modal id])} "Create Seder"]])])
+         #_#_[:h1.is-size-3.pt-3
+          "Sedarim"]
+         (when sedarim
+           [:ul.sedarim 
+            (for [{:keys [title id]} sedarim :when id] 
+              ^{:key id}[:li.mb-2
+                         [:a.seder-link.mr-2 {:data-testid id} title]
+                         [:a.button.is-small "Activate Seder"]])]
+         ))]]]
+   [wave-bottom]]])
 
 
 
@@ -187,7 +197,7 @@
                 expand (when dropdown? "is-active")]
            [:div.dropdown {:class expand}
             [:div {:class "dropdown-trigger"}
-             [:button.button {:readonly true
+             [:button.button {:readOnly true
                               :aria-haspopup "true", :aria-controls "dropdown-menu"}
               [:span "Base Haggadah"]
               [:span {:class "icon is-small"}

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -153,11 +153,10 @@
         [:input#seder-title.input {:type "email" :defaultValue "The title of your Seder"}]]
        [:div.field.is-grouped.is-grouped-left 
         [:div.control 
-         [:a.button.is-small.button  {:on-click (dispatch ::events/hide-seder-modal) #_#(re-frame/dispatch [::events/hide-seder-modal])} "Cancel"]]
+         [:a.button.is-small.button  {:on-click (dispatch ::events/hide-seder-modal)} "Cancel"]]
         [:div.control 
          [:a.button.is-small {:class (styles/submit-button)
                               :on-click (dispatch ::events/create-seder id (form-content "seder-title"))
-                              #_(re-frame/dispatch [::events/create-seder id (form-content "seder-title")])
                               :data-testid :submit} "Create"]]]]]
      [:button.modal-close.is-large]]))
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -156,7 +156,8 @@
          [:a.button.is-small.button  {:on-click (dispatch ::events/hide-seder-modal)} "Cancel"]]
         [:div.control 
          [:a.button.is-small {:class (styles/submit-button)
-                              :on-click (dispatch ::events/create-seder id (form-content "seder-title"))
+                              :on-click #_(dispatch ::events/create-seder id (form-content "seder-title"))
+                              #(re-frame/dispatch [::events/create-seder id (form-content "seder-title")])
                               :data-testid :submit} "Create"]]]]]
      [:button.modal-close.is-large]]))
 
@@ -175,7 +176,9 @@
           (str "Hello " @name ". Welcome. To make a new Haggadah, click the button to your right. To share and edit your existing Haggadah, look at your Haggadot below ")]])
       [:div.pl-6.buttons.is-right
        [:a.button.is-smalll.is-pulled-right.mt-2 {:data-testid :create-haggadah
-                                                        :on-click #(re-frame/dispatch [::push-state :haggadah-creation])}   "Create Haggadah"]]
+                                                  :on-click
+                                                  (dispatch ::push-state :haggadah-creation)
+                                                  #_#(re-frame/dispatch [::push-state :haggadah-creation])}   "Create Haggadah"]]
       [:div
        [seder-popup]
        [:h1.is-size-3

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -127,6 +127,8 @@
   [:div.page 
    [:div.container.is-large.hero.is-flex
     [:div.hero-body.pt-6
+     (let [haggadot @(re-frame/subscribe [::subs/haggadot])
+           sedarim @(re-frame/subscribe [::subs/sedarim])]
      [:div.pt-24.column
       (let [name (re-frame/subscribe [::subs/name])]
         [:div
@@ -138,8 +140,6 @@
       [:div
        [:h1.is-size-3
         "Haggadot created"]
-       (let [haggadot @(re-frame/subscribe [::subs/haggadot])
-             sedarim @(re-frame/subscribe [::subs/sedarim])]
          (when haggadot
            [:ul.haggadot 
             (for [{:keys [title id]} haggadot :when id] 
@@ -148,7 +148,7 @@
                                             :href (href :haggadah-view {:id id})} title]
                          [:a.button.is-small {:data-testid :create-seder
                                               :on-click #(re-frame/dispatch [::events/create-seder-modal id])} "Create Seder"]])])
-         #_#_[:h1.is-size-3.pt-3
+         [:h1.is-size-3.pt-3
           "Sedarim"]
          (when sedarim
            [:ul.sedarim 
@@ -156,8 +156,8 @@
               ^{:key id}[:li.mb-2
                          [:a.seder-link.mr-2 {:data-testid id} title]
                          [:a.button.is-small "Activate Seder"]])]
-         ))]]]
-   [wave-bottom]]])
+         )]])]]
+   [wave-bottom]])
 
 
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -177,8 +177,7 @@
       [:div.pl-6.buttons.is-right
        [:a.button.is-smalll.is-pulled-right.mt-2 {:data-testid :create-haggadah
                                                   :on-click
-                                                  (dispatch ::push-state :haggadah-creation)
-                                                  #_#(re-frame/dispatch [::push-state :haggadah-creation])}   "Create Haggadah"]]
+                                                  (dispatch ::push-state :haggadah-creation)}   "Create Haggadah"]]
       [:div
        [seder-popup]
        [:h1.is-size-3
@@ -190,8 +189,7 @@
                          [:a.haggadah-link {:data-testid :haggadah-link 
                                             :href (href :haggadah-view {:id id})} title]
                          [:a.button.is-small {:data-testid :create-seder
-                                              :on-click #(re-frame/dispatch [::events/create-seder-modal id])} "Create Seder"]])])
-         [:h1.is-size-3.pt-3
+                                              :on-click (dispatch ::events/create-seder-modal id)} "Create Seder"]])]) [:h1.is-size-3.pt-3
           "Sedarim"]
          (when sedarim
            [:ul.sedarim 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -41,7 +41,7 @@
   "Pre: takkes an event and args for the event
   Post: returns a function which dispatches the event with the args passed"
   [event & args]
-  #(re-frame/dispatch (apply conj [] event args)))
+  (fn [_] (re-frame/dispatch (apply conj [] event args))))
 
 
 (defn top-menu [{:keys [router current-route]}]
@@ -211,7 +211,8 @@
    [:div.container.has-text-centered.pt-3
     [:div.pb-5
      "Your Haggadah is ready. Please click the button below to return to the dashboard and see it"]
-    [:div [:a.button.is-focused.is-link {:data-testid :return :on-click #(re-frame/dispatch [::push-state :dashboard])} "Return to dashboard"]]]])
+    [:div [:a.button.is-focused.is-link {:data-testid :return
+                                         :on-click (dispatch ::push-state :dashboard)} "Return to dashboard"]]]])
 
 
 
@@ -242,9 +243,9 @@
               [:a.dropdown-item.is-active "Base Haggadah" ]]]])]
          [:div.field.is-grouped.is-grouped-right 
           [:a.button.mr-3 "Cancel"]
-          [:a.button {:class (styles/submit-button) :data-testid :add-haggadah :on-click #(re-frame/dispatch [::events/add-haggadah
-                                                                                        (form-content "haggadah-title")
-                                                                                         %])
+          [:a.button {:class (styles/submit-button)
+                      :data-testid :add-haggadah
+                      :on-click #(re-frame/dispatch [::events/add-haggadah (form-content "haggadah-title") %])
                               :id "submit"} "Create"]]]]]]]))
 
 (defn haggadah-view-panel

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -43,6 +43,7 @@
   [event & args]
   #(re-frame/dispatch (apply conj [] event args)))
 
+
 (defn top-menu [{:keys [router current-route]}]
   [:div {:class (styles/menu)}
    [:nav {:class "navbar", :role "navigation", :aria-label "main navigation"}
@@ -55,9 +56,9 @@
     (let [active-menu? @(re-frame/subscribe [::subs/active-menu?])
           active-menu (when active-menu? "is-active")]
      [:div#menu.navbar-menu {:class active-menu}
-      [:a.navbar-item {:class active-menu :on-click (dispatch ::push-state :home) #_(re-frame/dispatch [::push-state :home])} "Home"]
-      [:a.navbar-item {:class active-menu :on-click (dispatch ::push-state :about) #_(re-frame/dispatch [::push-state :about])} "About"]
-      [:a.navbar-item {:class active-menu :on-click #(re-frame/dispatch [::events/signout])} "Sign out"]]
+      [:a.navbar-item {:class active-menu :on-click (dispatch ::push-state :home) } "Home"]
+      [:a.navbar-item {:class active-menu :on-click (dispatch ::push-state :about) } "About"]
+      [:a.navbar-item {:class active-menu :on-click (dispatch ::events/signout)} "Sign out"]]
      )
     ]])
 
@@ -113,7 +114,9 @@
         [:div {:class "control"}
          [:button.is-small.button {:class (styles/cancel-button)}  "Cancel"]]
         [:div {:class "control"}
-         [:a.button.is-small {:class (styles/submit-button) :on-click  #(re-frame/dispatch [::events/login]) :data-testid :submit} "Submit"]]]
+         [:a.button.is-small {:class (styles/submit-button) :on-click (dispatch ::events/login)
+                             #_ #(re-frame/dispatch [::events/login]) :data-testid :submit} "Submit"]]]
+
        ]]]]])
 
 (defn wave-bottom

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -122,6 +122,35 @@
          [:g {:transform "translate(-4.000000, 76.000000)", :fill "#FFFFFF", :fill-rule "nonzero"}
           [:path {:d "M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"}]]]]])
 
+(defn form-content
+  "Pre: takes an id for a form field
+  Post: returns the text of the field if it exists, nil otherwise"
+  [id]
+  (-> (.getElementById js/document id)
+      (.-value)))
+
+(defn seder-popup
+  []
+  (let [id @(re-frame/subscribe [::subs/seder-modal])
+        active (when id "is-active")]
+    [:div.modal {:class active}
+     [:div.modal-background]
+     [:div.modal-content
+      [:form.box
+       [:div.text-centered.pb-2
+        "Please enter the title of the Seder"]
+       [:div.field
+        [:input#seder-title.input {:type "email" :defaultValue "The title of your Seder"}]]
+       [:div.field.is-grouped.is-grouped-left 
+        [:div.control 
+         [:a.button.is-small.button  {:on-click #(re-frame/dispatch [::events/hide-seder-modal])} "Cancel"]]
+        [:div.control 
+         [:a.button.is-small {:class (styles/submit-button) :on-click  #(re-frame/dispatch [::events/create-seder id
+                                                                                            (form-content "seder-title")])
+                              :data-testid :submit} "Create"]]]]]
+     [:button.modal-close.is-large]]))
+
+
 (defn dashboard-panel
   []
   [:div.page 
@@ -138,6 +167,7 @@
        [:a.button.is-smalll.is-pulled-right.mt-2 {:data-testid :create-haggadah
                                                         :on-click #(re-frame/dispatch [::push-state :haggadah-creation])}   "Create Haggadah"]]
       [:div
+       [seder-popup]
        [:h1.is-size-3
         "Haggadot created"]
          (when haggadot
@@ -161,12 +191,6 @@
 
 
 
-(defn form-content
-  "Pre: takes an id for a form field
-  Post: returns the text of the field if it exists, nil otherwise"
-  [id]
-  (-> (.getElementById js/document id)
-      (.-value)))
 
 
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -145,20 +145,18 @@
         active (when id "is-active")]
     [:div.modal {:class active}
      [:div.modal-background]
-     [:div.modal-content
-      [:form.box
-       [:div.text-centered.pb-2
-        "Please enter the title of the Seder"]
-       [:div.field
-        [:input#seder-title.input {:type "email" :defaultValue "The title of your Seder"}]]
-       [:div.field.is-grouped.is-grouped-left 
-        [:div.control 
-         [:a.button.is-small.button  {:on-click (dispatch ::events/hide-seder-modal)} "Cancel"]]
-        [:div.control 
-         [:a.button.is-small {:class (styles/submit-button)
-                              :on-click #_(dispatch ::events/create-seder id (form-content "seder-title"))
-                              #(re-frame/dispatch [::events/create-seder id (form-content "seder-title")])
-                              :data-testid :submit} "Create"]]]]]
+     [:div.modal-content [:form.box
+                          [:div.text-centered.pb-2
+                           "Please enter the title of the Seder"]
+                          [:div.field
+                           [:input#seder-title.input {:type "email" :defaultValue "The title of your Seder"}]]
+                          [:div.field.is-grouped.is-grouped-left 
+                           [:div.control 
+                            [:a.button.is-small.button  {:on-click (dispatch ::events/hide-seder-modal)} "Cancel"]]
+                           [:div.control 
+                            [:a.button.is-small {:class (styles/submit-button)
+                                                 :on-click #(re-frame/dispatch [::events/create-seder id (form-content "seder-title")])
+                                                 :data-testid :submit} "Create"]]]]]
      [:button.modal-close.is-large]]))
 
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -144,7 +144,9 @@
             (for [{:keys [title id]} haggadot :when id] 
               ^{:key id}[:li.mb-2
                          [:a.haggadah-link {:data-testid :haggadah-link 
-                              :href (href :haggadah-view {:id id})} title]])]))] ]]]
+                                            :href (href :haggadah-view {:id id})} title]
+                         [:a.button.is-small {:data-testid :create-seder
+                                              :on-click #(re-frame/dispatch [::events/create-seder-modal id])} "Create Seder"]])]))] ]]]
    [wave-bottom]])
 
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -114,8 +114,9 @@
         [:div {:class "control"}
          [:button.is-small.button {:class (styles/cancel-button)}  "Cancel"]]
         [:div {:class "control"}
-         [:a.button.is-small {:class (styles/submit-button) :on-click (dispatch ::events/login)
-                             #_ #(re-frame/dispatch [::events/login]) :data-testid :submit} "Submit"]]]
+         [:a.button.is-small {:class (styles/submit-button)
+                              :on-click (dispatch ::events/login)
+                              :data-testid :submit} "Submit"]]]
 
        ]]]]])
 
@@ -152,10 +153,11 @@
         [:input#seder-title.input {:type "email" :defaultValue "The title of your Seder"}]]
        [:div.field.is-grouped.is-grouped-left 
         [:div.control 
-         [:a.button.is-small.button  {:on-click #(re-frame/dispatch [::events/hide-seder-modal])} "Cancel"]]
+         [:a.button.is-small.button  {:on-click (dispatch ::events/hide-seder-modal) #_#(re-frame/dispatch [::events/hide-seder-modal])} "Cancel"]]
         [:div.control 
-         [:a.button.is-small {:class (styles/submit-button) :on-click  #(re-frame/dispatch [::events/create-seder id
-                                                                                            (form-content "seder-title")])
+         [:a.button.is-small {:class (styles/submit-button)
+                              :on-click (dispatch ::events/create-seder id (form-content "seder-title"))
+                              #_(re-frame/dispatch [::events/create-seder id (form-content "seder-title")])
                               :data-testid :submit} "Create"]]]]]
      [:button.modal-close.is-large]]))
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -37,6 +37,12 @@
          [:g {:transform "translate(-4.000000, 76.000000)", :fill "#FFFFFF", :fill-rule "nonzero"}
           [:path {:d "M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"}]]]]])
 
+(defn dispatch
+  "Pre: takkes an event and args for the event
+  Post: returns a function which dispatches the event with the args passed"
+  [event & args]
+  #(re-frame/dispatch (apply conj [] event args)))
+
 (defn top-menu [{:keys [router current-route]}]
   [:div {:class (styles/menu)}
    [:nav {:class "navbar", :role "navigation", :aria-label "main navigation"}
@@ -49,8 +55,8 @@
     (let [active-menu? @(re-frame/subscribe [::subs/active-menu?])
           active-menu (when active-menu? "is-active")]
      [:div#menu.navbar-menu {:class active-menu}
-      [:a.navbar-item {:class active-menu :on-click  #(re-frame/dispatch [::push-state :home])} "Home"]
-      [:a.navbar-item {:class active-menu :on-click  #(re-frame/dispatch [::push-state :about])} "About"]
+      [:a.navbar-item {:class active-menu :on-click (dispatch ::push-state :home) #_(re-frame/dispatch [::push-state :home])} "Home"]
+      [:a.navbar-item {:class active-menu :on-click (dispatch ::push-state :about) #_(re-frame/dispatch [::push-state :about])} "About"]
       [:a.navbar-item {:class active-menu :on-click #(re-frame/dispatch [::events/signout])} "Sign out"]]
      )
     ]])
@@ -231,7 +237,7 @@
               [:a.dropdown-item.is-active "Base Haggadah" ]]]])]
          [:div.field.is-grouped.is-grouped-right 
           [:a.button.mr-3 "Cancel"]
-          [:a.button {:class (styles/submit-button):data-testid :add-haggadah :on-click #(re-frame/dispatch [::events/add-haggadah
+          [:a.button {:class (styles/submit-button) :data-testid :add-haggadah :on-click #(re-frame/dispatch [::events/add-haggadah
                                                                                         (form-content "haggadah-title")
                                                                                          %])
                               :id "submit"} "Create"]]]]]]]))

--- a/test/acceptance/dashboard_test.clj
+++ b/test/acceptance/dashboard_test.clj
@@ -165,7 +165,7 @@
     (map id-and-title sedarim)))
 
 (t/deftest create-seder-test
-  (t/testing "When the current user has a Haggadah and creates a Seder which uses that Haggadah, a new Seder with the same Haggadah will appear in the user's collection of Sedarim in firestore"
+  (t/testing "When the current user has a Haggadah and creates a Seder which uses that Haggadah, a new Seder with the same Haggadah will appear in the user's collection of Sedarim"
     (let [id (c/fs-store-haggadah {:title "Haggadah 1"
                                    :type "haggadah"
                                    :content [{:type "bracha" :title "hello" :text "bracha"}]}

--- a/test/acceptance/dashboard_test.clj
+++ b/test/acceptance/dashboard_test.clj
@@ -87,9 +87,9 @@
         true latest?))))
 
 (def haggadot
-  [{:content {:bracha  {:content "Amir's Haggadah" } } :title "Third"}
-   {:content {:bracha  {:content "Amir's Haggadah" } } :title "Second"}
-   {:content {:bracha  {:content "Amir's Haggadah" } } :title "First"}])
+  [{:type "haggadah" :content [{:type "bracha" :title "Amir's Haggadah"}] :title "Third"}
+   {:type "haggadah" :content [{:type "bracha" :title "Amir's Haggadah"}] :title "Second"}
+   {:type "haggadah" :content [{:type "bracha" :title "Amir's Haggadah"}] :title "First"}])
 
 (defn haggadot-titles
   "Pre: takes a collection of Haggadot

--- a/test/acceptance/dashboard_test.clj
+++ b/test/acceptance/dashboard_test.clj
@@ -68,9 +68,20 @@
       first
       (= id)))
 
+(def coll-type
+  {:sedarim {:fn/has-class :sedarim}
+   :haggadot {:fn/has-class :haggadot}})
+
+(defn wait-for-collection
+  "Pre: takes a collection type
+  Post: waits until a collection of the same type is found on the page"
+  [coll]
+  (e/wait-visible driver (coll coll-type)))
+
 (defn wait-for-haggadot
   []
-  (e/wait-visible driver {:fn/has-class :haggadot}))
+  (wait-for-collection :haggadot))
+
 
 (t/deftest create-haggadah-test
   (t/testing "When the current user creates a new Haggadah and goes back to the dashboard, the Haggadah is listed first among the Haggadot and a new Haggadah with the same details is added to firestore"


### PR DESCRIPTION
## Summary

The user can create a seder by clicking the "Create Seder" button next to a Haggadah.

closes #66

## Changes

### src/haggadah/events.cljs
* Added handlers for creating a seder
* Added handlers for fetching the sedarim

### src/haggadah/views.cljs
* Added a popup Seder creation form which appears when the user clicks the "Create Seder" button  
<img width="1020" alt="image" src="https://github.com/ebarylko/my-haggadah/assets/62489101/900e761d-c5c5-4a1e-857d-6efee409e57c">

* Changed `dashboard-panel-view` so that the user's Sedarim are displayed below the Haggadot and a "Create Seder" button appears beside each Haggadah
<img width="1350" alt="image" src="https://github.com/ebarylko/my-haggadah/assets/62489101/70e13410-12ca-4645-b256-3c893479e94b">



### test/acceptance/dashboard_test.clj
* Added `create-seder-test` which checks that when a user creates a Seder for a specific Haggadah, a new Seder with the path to the Haggadah is added to the user's collection of Sedarim in firestore

### .github/workflows/test.yml
* Updated the version of google chrome used
