### PR TITLE
add environment variable for chrome binary path

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: install chrome
         run: |
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_115.0.5790.102-1_amd64.deb
           sudo apt-get update
           sudo apt-get install -y -f /tmp/chrome.deb
           rm /tmp/chrome.deb

--- a/test/acceptance/core.clj
+++ b/test/acceptance/core.clj
@@ -21,12 +21,12 @@
           "--disable-extensions"
           "--start-maximized"]})
 
-(def driver (e/chrome-headless
-             (case (System/getProperty "os.name")
-               "linux" driver-config
-               (assoc driver-config :path-browser "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"))))
+(def driver
+  (e/chrome-headless
+   (assoc driver-config :path-browser (System/getenv "CHROME_BINARY"))))
 
 (defn- build-firebase-options []
+  (println "The operating system "(System/getenv "CHROME_BINARY"))
   (-> (new FirebaseOptions$Builder)
       (.setCredentials (EmulatorCredentials.))
       (.setProjectId project-id)

--- a/test/acceptance/core.clj
+++ b/test/acceptance/core.clj
@@ -24,7 +24,7 @@
 (def driver (e/chrome-headless
              (case (System/getProperty "os.name")
                "linux" driver-config
-               :else (conj driver-config :path-browser "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"))))
+               (assoc driver-config :path-browser "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"))))
 
 (defn- build-firebase-options []
   (-> (new FirebaseOptions$Builder)

--- a/test/acceptance/core.clj
+++ b/test/acceptance/core.clj
@@ -14,12 +14,17 @@
 
 (def project-id (env :gcloud-project))
 
+(def driver-config
+  {:args ["no-sandbox"
+          "--disable-dev-shm-usage"
+          "--disable-gpu"
+          "--disable-extensions"
+          "--start-maximized"]})
+
 (def driver (e/chrome-headless
-             {:args ["no-sandbox"
-                     "--disable-dev-shm-usage"
-                     "--disable-gpu"
-                     "--disable-extensions"
-                     "--start-maximized"]}))
+             (case (System/getProperty "os.name")
+               "linux" driver-config
+               :else (conj driver-config :path-browser "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"))))
 
 (defn- build-firebase-options []
   (-> (new FirebaseOptions$Builder)

--- a/test/acceptance/core.clj
+++ b/test/acceptance/core.clj
@@ -26,7 +26,6 @@
    (assoc driver-config :path-browser (System/getenv "CHROME_BINARY"))))
 
 (defn- build-firebase-options []
-  (println "The operating system "(System/getenv "CHROME_BINARY"))
   (-> (new FirebaseOptions$Builder)
       (.setCredentials (EmulatorCredentials.))
       (.setProjectId project-id)


### PR DESCRIPTION
## Summary

The environment variable for the chrome binary file path is included in the driver configuration

closes #70

## Changes

### test/acceptance/core.clj
* Changed the driver so it includes a path to the chrome binary file.

### .github/workflows/test.yaml
* Updated the version of google chrome to 115
