### PR TITLE
change login function so it does not use hardcoded values

### DIFF
--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -203,8 +203,9 @@
 (re-frame/reg-event-fx
  ::login
  interceptors
- (fn [_ [_]]
-   {::email-login! {:email "han@skywalker.com" :password "123456789" :on-success #(re-frame/dispatch [::push-state :dashboard]) :on-error #(re-frame/dispatch [::error %])}}))
+ (fn [_ [_ email pwd]]
+   (println "HEre is the login")
+   {::email-login! {:email email :password pwd :on-success #(re-frame/dispatch [::push-state :dashboard]) :on-error #(re-frame/dispatch [::error %])}}))
 
 
 (re-frame/reg-fx

--- a/src/haggadah/events.cljs
+++ b/src/haggadah/events.cljs
@@ -203,8 +203,7 @@
 (re-frame/reg-event-fx
  ::login
  interceptors
- (fn [_ [_ email pwd]]
-   (println "HEre is the login")
+ (fn [_ [email pwd]]
    {::email-login! {:email email :password pwd :on-success #(re-frame/dispatch [::push-state :dashboard]) :on-error #(re-frame/dispatch [::error %])}}))
 
 

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -38,7 +38,7 @@
           [:path {:d "M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"}]]]]])
 
 (defn dispatch
-  "Pre: takkes an event and args for the event
+  "Pre: takes an event and args for the event
   Post: returns a function which dispatches the event with the args passed"
   [event & args]
   (fn [_] (re-frame/dispatch (apply conj [] event args))))
@@ -87,8 +87,12 @@
       [:a.button.is-focused {:href (href :login) :data-testid :login} "Log in"]
       [:a.button  "Register"]]]]])
 
-
-
+(defn form-content
+  "Pre: takes an id for a form field
+  Post: returns the text of the field if it exists, nil otherwise"
+  [id]
+  (-> (.getElementById js/document id)
+      (.-value)))
 
 (defn login-panel []
   [:div.is-dark {:class (styles/login-page)}
@@ -101,13 +105,13 @@
        [:div {:class "field"}
         [:label "Email"]
         [:div {:class "control has-icons-left has-icons-right"}
-         [:input {:class "input", :type "email", :placeholder "Email input", :defaultValue "han@skywalker.com"}]
+         [:input#email {:class "input", :type "email", :placeholder "Email input", :defaultValue "han@skywalker.com"}]
          [:span {:class "icon is-small is-left"}
           [:i {:class "fas fa-envelope"}]]]]
        [:div.field
         [:label  "Password"]
         [:div {:class "control has-icons-left has-icons-right"}
-         [:input {:class "input", :type "text", :placeholder "Text input", :defaultValue "123456789"}]
+         [:input#password {:class "input", :type "text", :placeholder "Text input", :defaultValue "123456789"}]
          [:span {:class "icon is-small is-left"}
           [:i {:class "fas fa-key"}]]]]
        [:div.field.is-grouped.is-grouped-right 
@@ -115,7 +119,8 @@
          [:button.is-small.button {:class (styles/cancel-button)}  "Cancel"]]
         [:div {:class "control"}
          [:a.button.is-small {:class (styles/submit-button)
-                              :on-click (dispatch ::events/login)
+                              :on-click #(re-frame/dispatch [::events/login (form-content "email") (form-content "password")])
+                              #_(dispatch ::events/login)
                               :data-testid :submit} "Submit"]]]
 
        ]]]]])
@@ -132,12 +137,6 @@
          [:g {:transform "translate(-4.000000, 76.000000)", :fill "#FFFFFF", :fill-rule "nonzero"}
           [:path {:d "M0.457,34.035 C57.086,53.198 98.208,65.809 123.822,71.865 C181.454,85.495 234.295,90.29 272.033,93.459 C311.355,96.759 396.635,95.801 461.025,91.663 C486.76,90.01 518.727,86.372 556.926,80.752 C595.747,74.596 622.372,70.008 636.799,66.991 C663.913,61.324 712.501,49.503 727.605,46.128 C780.47,34.317 818.839,22.532 856.324,15.904 C922.689,4.169 955.676,2.522 1011.185,0.432 C1060.705,1.477 1097.39,3.129 1121.236,5.387 C1161.703,9.219 1208.621,17.821 1235.4,22.304 C1285.855,30.748 1354.351,47.432 1440.886,72.354 L1441.191,104.352 L1.121,104.031 L0.457,34.035 Z"}]]]]])
 
-(defn form-content
-  "Pre: takes an id for a form field
-  Post: returns the text of the field if it exists, nil otherwise"
-  [id]
-  (-> (.getElementById js/document id)
-      (.-value)))
 
 (defn seder-popup
   []

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -120,7 +120,6 @@
         [:div {:class "control"}
          [:a.button.is-small {:class (styles/submit-button)
                               :on-click #(re-frame/dispatch [::events/login (form-content "email") (form-content "password")])
-                              #_(dispatch ::events/login)
                               :data-testid :submit} "Submit"]]]
 
        ]]]]])

--- a/test/haggadah/events_test.cljs
+++ b/test/haggadah/events_test.cljs
@@ -45,8 +45,8 @@
    (routes/init-routes!)
    (core/firebase-init!)
    (rf/dispatch-sync [::events/initialize-db])
-   (rf/dispatch [::events/login])
-   (rf-test/wait-for [::events/fetch-haggadot] 
+   (rf/dispatch [::events/login "han@skywalker.com" "123456789"])
+   (rf-test/wait-for [::events/fetch-haggadot]
     (let [user (rf/subscribe [::subs/user])
           name (rf/subscribe [::subs/name])]
       (t/are [x y] (= x y)

--- a/test/haggadah/events_test.cljs
+++ b/test/haggadah/events_test.cljs
@@ -26,18 +26,25 @@
 
 (def user-not-found "auth/user-not-found")
 
-#_(t/deftest unregistered-user-login
+(def incorrect-password "auth/wrong-password")
+
+(t/deftest unregistered-user-login
   (rf-test/run-test-async
    (core/firebase-init!)
    (rf/dispatch-sync [::events/initialize-db])
-   (println "Before logging in")
-   (rf/dispatch-sync [::events/login])
-   (println "After logging in")
+   (rf/dispatch-sync [::events/login "jan@weir.com" "123456789"])
    (rf-test/wait-for [::events/error]
-                     (println "Found the error")
                      (let [{:keys [code]} @(rf/subscribe [::subs/error])]
                        (t/is (= user-not-found code))))))
 
+(t/deftest incorrect-pwd-login
+  (rf-test/run-test-async
+   (core/firebase-init!)
+   (rf/dispatch-sync [::events/initialize-db])
+   (rf/dispatch-sync [::events/login "han@skywalker.com" "12345678"])
+   (rf-test/wait-for [::events/error]
+                     (let [{:keys [code]} @(rf/subscribe [::subs/error])]
+                       (t/is (= incorrect-password code))))))
 
 
 (t/deftest registered-user-login


### PR DESCRIPTION
## Summary

The user can log in using the email and password they entered on the login form

closes #46

## Changes

### test/haggadah/events_test.cljs
* Added `incorrect-pwd-login` test which checks that logging in with an incorrect password produces an error about the password used

### src/haggadah/events.cljs
* Changed `login` event so it uses the email and password the user entered
