### PR TITLE
Add acceptance test for checking that the cancel button on the login page works

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "test:watch": "firebase emulators:exec --project my-haggadah 'npx shadow-cljs watch ci ci-setup'",
         "test:build": "npx shadow-cljs compile ci ci-setup ",
         "emulators": "firebase emulators:start --project my-haggadah --import=emulator_data --export-on-exit=emulator_data",
-        "acceptance": "cd test/acceptance && npm run acceptance:base && firebase emulators:exec --project my-haggadah 'lein test'",
+        "acceptance": "cd test/acceptance && npm run acceptance:base && firebase emulators:exec --project my-haggadah 'lein test :only acceptance.page-navigation-test'",
         "acceptance:base": "cp -r resources  test/acceptance && npx shadow-cljs release acceptance",
 		"act:pr": "act pull_request --artifact-server-path /tmp/artifacts "
 	},

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "test:watch": "firebase emulators:exec --project my-haggadah 'npx shadow-cljs watch ci ci-setup'",
         "test:build": "npx shadow-cljs compile ci ci-setup ",
         "emulators": "firebase emulators:start --project my-haggadah --import=emulator_data --export-on-exit=emulator_data",
-        "acceptance": "cd test/acceptance && npm run acceptance:base && firebase emulators:exec --project my-haggadah 'lein test :only acceptance.page-navigation-test'",
+        "acceptance": "cd test/acceptance && npm run acceptance:base && firebase emulators:exec --project my-haggadah 'lein test'",
         "acceptance:base": "cp -r resources  test/acceptance && npx shadow-cljs release acceptance",
 		"act:pr": "act pull_request --artifact-server-path /tmp/artifacts "
 	},

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -127,6 +127,7 @@
 
        ]]]]])
 
+
 (defn wave-bottom
   []
 [:div {:class "relative -mt-12 lg:-mt-24"}

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -116,7 +116,7 @@
           [:i {:class "fas fa-key"}]]]]
        [:div.field.is-grouped.is-grouped-right 
         [:div {:class "control"}
-         [:button.is-small.button {:on-click (dispatch ::push-state :home)
+         [:a.is-small.button {:on-click (dispatch ::push-state :home)
                                    :class (styles/cancel-button)
                                    :data-testid :cancel}
           "Cancel"]]

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -117,7 +117,9 @@
        [:div.field.is-grouped.is-grouped-right 
         [:div {:class "control"}
          [:button.is-small.button {:on-click (dispatch ::push-state :home)
-                                   :class (styles/cancel-button)}  "Cancel"]]
+                                   :class (styles/cancel-button)
+                                   :data-testid :cancel}
+          "Cancel"]]
         [:div {:class "control"}
          [:a.button.is-small {:class (styles/submit-button)
                               :on-click #(re-frame/dispatch [::events/login (form-content "email") (form-content "password")])

--- a/test/acceptance/page_navigation_test.clj
+++ b/test/acceptance/page_navigation_test.clj
@@ -1,18 +1,10 @@
 (ns acceptance.page-navigation-test
   (:require  [clojure.test :as t]
              [etaoin.api :as e]
-             [acceptance.core :as c :refer [driver]]
-             ))
-
+             [acceptance.core :as c :refer [driver]]))
 
 (t/use-fixtures :once c/init-firebase)
 (t/use-fixtures :each c/with-screenshot c/delete-fs-emulator-data)
-
-(defn ->home
-  "Pre: takes nothing
-  Post: takes you to the home page"
-  []
-  (e/go driver "http://localhost:5000/"))
 
 (defn home->login
   "Pre: takes nothing
@@ -36,6 +28,8 @@
   (e/wait-visible driver {:data-testid :login}))
 
 (defn at-home-page?
+  "Pre: takes nothing
+  Post: returns true if the user is at the home page. False otherwise"
   []
   (e/exists? driver {:data-testid :login}))
 

--- a/test/acceptance/page_navigation_test.clj
+++ b/test/acceptance/page_navigation_test.clj
@@ -4,6 +4,10 @@
              [acceptance.core :as c :refer [driver]]
              ))
 
+
+(t/use-fixtures :once c/init-firebase)
+(t/use-fixtures :each c/with-screenshot c/delete-fs-emulator-data)
+
 (defn ->home
   "Pre: takes nothing
   Post: takes you to the home page"
@@ -16,20 +20,24 @@
   []
   (doto driver
     (e/go "http://localhost:5000/")
-   (e/click-visible {:data-testid :login})
-   (e/wait-visible {:data-testid :submit})))
+    (e/click-visible {:data-testid :login})
+    (e/wait-visible {:data-testid :submit})))
 
 (defn click-on-cancel-button
   "Pre: takes nothing
   Post: clicks on the cancel button on the page"
   []
-  (e/click-visible {:data-testid :cancel}))
+  (println "The button exists " (e/exists? driver {:data-testid :cancel}))
+  (let [button (e/query driver {:data-testid :cancel})]
+    (e/js-execute driver "arguments[0].click()" (e/el->ref button))
+  #_(e/click-visible driver {:data-testid :cancel})
+  (e/wait 6)))
 
 (defn wait-for-home-page
   "Pre: takes nothing
   Post: waits for the home page to the rendered"
   []
-  (e/wait-visible {:data-testid :login}))
+  (e/wait-visible driver {:data-testid :login}))
 
 (defn at-home-page?
   []
@@ -40,11 +48,13 @@
   Post: returns the current page the user is on"
   []
   (cond
-    (at-home-page?) :home-page))
+    (at-home-page?) :home-page)
+  :else :invalid-page)
 
 (t/deftest click-cancel-button-test
   (t/testing "When the user goes to the login page and clicks the cancel button, they should return to the home page"
     (home->login)
     (click-on-cancel-button)
-    (wait-for-home-page)
-    ))
+    #_(wait-for-home-page)
+    (let [current-page (current-page)]
+      (t/is (= :home-page current-page)))))

--- a/test/acceptance/page_navigation_test.clj
+++ b/test/acceptance/page_navigation_test.clj
@@ -1,0 +1,50 @@
+(ns acceptance.page-navigation-test
+  (:require  [clojure.test :as t]
+             [etaoin.api :as e]
+             [acceptance.core :as c :refer [driver]]
+             ))
+
+(defn ->home
+  "Pre: takes nothing
+  Post: takes you to the home page"
+  []
+  (e/go driver "http://localhost:5000/"))
+
+(defn home->login
+  "Pre: takes nothing
+  Post: takes you from the home page to the login page"
+  []
+  (doto driver
+    (e/go "http://localhost:5000/")
+   (e/click-visible {:data-testid :login})
+   (e/wait-visible {:data-testid :submit})))
+
+(defn click-on-cancel-button
+  "Pre: takes nothing
+  Post: clicks on the cancel button on the page"
+  []
+  (e/click-visible {:data-testid :cancel}))
+
+(defn wait-for-home-page
+  "Pre: takes nothing
+  Post: waits for the home page to the rendered"
+  []
+  (e/wait-visible {:data-testid :login}))
+
+(defn at-home-page?
+  []
+  (e/exists? driver {:data-testid :login}))
+
+(defn current-page
+  "Pre: takes nothing
+  Post: returns the current page the user is on"
+  []
+  (cond
+    (at-home-page?) :home-page))
+
+(t/deftest click-cancel-button-test
+  (t/testing "When the user goes to the login page and clicks the cancel button, they should return to the home page"
+    (home->login)
+    (click-on-cancel-button)
+    (wait-for-home-page)
+    ))

--- a/test/acceptance/page_navigation_test.clj
+++ b/test/acceptance/page_navigation_test.clj
@@ -27,11 +27,7 @@
   "Pre: takes nothing
   Post: clicks on the cancel button on the page"
   []
-  (println "The button exists " (e/exists? driver {:data-testid :cancel}))
-  (let [button (e/query driver {:data-testid :cancel})]
-    (e/js-execute driver "arguments[0].click()" (e/el->ref button))
-  #_(e/click-visible driver {:data-testid :cancel})
-  (e/wait 6)))
+  (e/click-visible driver {:data-testid :cancel}))
 
 (defn wait-for-home-page
   "Pre: takes nothing
@@ -48,13 +44,13 @@
   Post: returns the current page the user is on"
   []
   (cond
-    (at-home-page?) :home-page)
-  :else :invalid-page)
+    (at-home-page?) :home-page
+    :else :invalid-page))
 
 (t/deftest click-cancel-button-test
   (t/testing "When the user goes to the login page and clicks the cancel button, they should return to the home page"
     (home->login)
     (click-on-cancel-button)
-    #_(wait-for-home-page)
+    (wait-for-home-page)
     (let [current-page (current-page)]
       (t/is (= :home-page current-page)))))


### PR DESCRIPTION
## Summary

There is a test checking that clicking the cancel button on the login page returns the user to the home page 

closes #80

## Changes

### test/acceptance/page_navigation_test.clj
* Added `click-cancel-button-test` which checks that given a user at the login page, clicking the cancel button returns the user to the home page

