### PR TITLE
Add english and hebrew content for each song

### DIFF
--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -5,8 +5,8 @@
   {:type :bracha :title title :hebrew hebrew-text :english english-text})
 
 (defn song
-  [title text]
-  {:type :song :title title :text text})
+  [title hebrew-text english-text]
+  {:type :song :title title :hebrew hebrew-text :english english-text})
 
 (defn cell
   [content]
@@ -69,10 +69,11 @@
    [:div.text.hebrew.pb-3 hebrew]
    [:div.english-text english]])
 
-(defmethod render-haggadah :song [{:keys [title text]}]
+(defmethod render-haggadah :song [{:keys [title hebrew english]}]
   [:div.song
    [:div.title title]
-   [:div.text text]])
+   [:div.text.hebrew.pb-3 hebrew]
+   [:div.english-text english]])
 
 (defmethod render-haggadah :table [{:keys [title rows]}]
   [:div.table.is-bordered

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -16,7 +16,8 @@
 
 (t/deftest render-song-test
   (t/testing "When rendering the song, returns the title and content"
-    (let [song (dsl/song "Ki lo nae" "כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה. אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו"
+    (let [song (dsl/song "Ki lo nae"
+                         "כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה. אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו"
                          "Since for Him it is pleasant, for Him it is suited." )
           expected [:div.song
                     [:div.title "Ki lo nae" ]

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -16,10 +16,12 @@
 
 (t/deftest render-song-test
   (t/testing "When rendering the song, returns the title and content"
-    (let [song (dsl/song "Ki lo nae" "כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה. אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו")
+    (let [song (dsl/song "Ki lo nae" "כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה. אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו"
+                         "Since for Him it is pleasant, for Him it is suited." )
           expected [:div.song
                     [:div.title "Ki lo nae" ]
-                    [:div.text "כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה. אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו"]]]
+                    [:div.text.hebrew.pb-3 "כִּי לוֹ נָאֶה, כִּי לוֹ יָאֶה. אַדִּיר בִּמְלוּכָה, בָּחוּר כַּהֲלָכָה, גְּדוּדָיו"]
+                    [:div.english-text "Since for Him it is pleasant, for Him it is suited."]]]
       (t/is (= expected (dsl/render-haggadah song))))))
 
 (t/deftest render-table-test


### PR DESCRIPTION
## Summary

The user can now see songs which contain English and Hebrew content
Here is how a song looks

<img width="750" alt="image" src="https://github.com/ebarylko/my-haggadah/assets/62489101/07d99c52-d9ad-44e3-ac14-ec76c0be108b">


closes #88

## Changes

### src/haggadah/dsl.cljs
* Changed `song` so it includes English and Hebrew content

