### PR TITLE
Render instruction using dsl

### DIFF
--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -75,7 +75,7 @@
 
 (defmethod render-haggadah :instruction [{:keys [hebrew english]}]
   [:div.instruction
-   [:div.hebrew-instr hebrew]
+   [:div.hebrew-instr.pb-3 hebrew]
    [:div.english-instr english]])
 
 (defmethod render-haggadah :song [{:keys [title hebrew english]}]

--- a/src/haggadah/dsl.cljs
+++ b/src/haggadah/dsl.cljs
@@ -8,6 +8,10 @@
   [title hebrew-text english-text]
   {:type :song :title title :hebrew hebrew-text :english english-text})
 
+(defn instruction
+  [hebrew-text english-text]
+  {:type :instruction :english english-text :hebrew hebrew-text})
+
 (defn cell
   [content]
   [:td content])
@@ -68,6 +72,11 @@
    [:div.title title]
    [:div.text.hebrew.pb-3 hebrew]
    [:div.english-text english]])
+
+(defmethod render-haggadah :instruction [{:keys [hebrew english]}]
+  [:div.instruction
+   [:div.hebrew-instr hebrew]
+   [:div.english-instr english]])
 
 (defmethod render-haggadah :song [{:keys [title hebrew english]}]
   [:div.song

--- a/src/haggadah/styles.cljs
+++ b/src/haggadah/styles.cljs
@@ -35,6 +35,10 @@
           :background-color    :white}]
   [:nav.navbar {:background-color :transparent}]
   [:form {:background form-background}]
+  [:.english-instr {:text-align :left
+                    :font-size :1rem}]
+  [:.hebrew-instr {:text-align :right
+                    :font-size :1rem}]
   [:.english-text {:text-align :left
               :font-size :1.25rem}]
   [:.page {:background page-background

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -309,13 +309,7 @@
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:section.container.is-flex
-       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} (dsl/render-haggadah
-                                                               (dsl/haggadah "Haggadah title"
-                                                                (dsl/instruction "בליל רִאשון אומרים:"
-                                                                                 "On the first night we say:" )
-                                                                (dsl/song "" "וּבְכֵן וַיְהִי בַּחֲצִי הַלַּיְלָה." "English")
-                                                                )
-                                                               )#_text ]])])
+       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} text ]])])
 
 (defn about-panel
   []

--- a/src/haggadah/views.cljs
+++ b/src/haggadah/views.cljs
@@ -309,7 +309,13 @@
   [:div.page.is-flex.is-flex-grow-1 {:class (styles/haggadah-view)}
     (let [text @(re-frame/subscribe [::subs/haggadah-text])]
       [:section.container.is-flex
-       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} text ]])])
+       [:div.box.is-flex-grow-1 {:data-testid :haggadah-text} (dsl/render-haggadah
+                                                               (dsl/haggadah "Haggadah title"
+                                                                (dsl/instruction "בליל רִאשון אומרים:"
+                                                                                 "On the first night we say:" )
+                                                                (dsl/song "" "וּבְכֵן וַיְהִי בַּחֲצִי הַלַּיְלָה." "English")
+                                                                )
+                                                               )#_text ]])])
 
 (defn about-panel
   []

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -31,7 +31,7 @@
           expected [:div.instruction
                     [:div.hebrew-instr "Hebrew"]
                     [:div.english-instr "English"]]]
-      (t/is (= expected instruction)))))
+      (t/is (= expected (dsl/render-haggadah instruction))))))
 
 (t/deftest render-table-test
   (t/testing "When rendering the table, each row and the content within is returned"

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -29,7 +29,7 @@
   (t/testing "When rendering an instruction, returns the content in English and in Hebrew"
     (let [instruction (dsl/instruction "Hebrew" "English")
           expected [:div.instruction
-                    [:div.hebrew-instr "Hebrew"]
+                    [:div.hebrew-instr.pb-3 "Hebrew"]
                     [:div.english-instr "English"]]]
       (t/is (= expected (dsl/render-haggadah instruction))))))
 

--- a/test/haggadah/dsl_test.cljs
+++ b/test/haggadah/dsl_test.cljs
@@ -25,6 +25,14 @@
                     [:div.english-text "Since for Him it is pleasant, for Him it is suited."]]]
       (t/is (= expected (dsl/render-haggadah song))))))
 
+(t/deftest render-instruction-test
+  (t/testing "When rendering an instruction, returns the content in English and in Hebrew"
+    (let [instruction (dsl/instruction "Hebrew" "English")
+          expected [:div.instruction
+                    [:div.hebrew-instr "Hebrew"]
+                    [:div.english-instr "English"]]]
+      (t/is (= expected instruction)))))
+
 (t/deftest render-table-test
   (t/testing "When rendering the table, each row and the content within is returned"
     (let [table (dsl/table "Las Diez Plagas" 


### PR DESCRIPTION
## Summary 

The user can now view a Haggadah which contains an instruction

<img width="941" alt="Screen Shot 2023-08-08 at 11 11 19 AM" src="https://github.com/ebarylko/my-haggadah/assets/62489101/2a857dee-c9d5-425f-afa1-82325d3acb9c">


closes #89

## Changes

### test/haggadah/dsl_test.cljs
* Added `render-instruction-test` which checks that given an instruction, rendering it returns the English and Hebrew content

